### PR TITLE
Fix documentation: eval_type parameter and module structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,14 @@ uv run ruff format && uv run ruff check --fix && uv run mypy src/pyfia/
 ```
 pyfia/
 ├── src/pyfia/           # Library source code
-│   ├── core/            # Database and settings
+│   ├── core/            # Database, backends, and settings
 │   ├── estimation/      # Statistical estimation
 │   ├── filtering/       # Domain filtering
-│   └── downloader/      # FIA data download from DataMart
+│   ├── downloader/      # FIA data download from DataMart
+│   ├── evalidator/      # EVALIDator API client for validation
+│   ├── validation.py    # Input validation utilities
+│   ├── utils/           # Reference table helpers
+│   └── constants/       # FIA constants and standard values
 ├── tests/               # Test suite
 ├── docs/                # Technical documentation
 ├── ../business/         # Business docs (outside repo)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from pyfia import FIA, biomass, tpa, volume, area
 
 with FIA("path/to/FIA_database.duckdb") as db:
     db.clip_by_state(37)  # North Carolina
-    db.clip_most_recent(eval_type="EXPVOL")
+    db.clip_most_recent(eval_type="VOL")
 
     # Core estimates
     trees = tpa(db, tree_domain="STATUSCD == 1")

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -45,21 +45,35 @@ uv run mkdocs build   # Build for deployment
 pyfia/
 ├── core/               # Database and reader functionality
 │   ├── fia.py         # Main FIA database class
-│   └── data_reader.py # Efficient data loading
-├── estimation/         # Statistical estimation (~2,000 lines)
+│   ├── data_reader.py # Efficient data loading
+│   └── backends/      # DuckDB, SQLite, MotherDuck backends
+├── estimation/         # Statistical estimation
 │   ├── base.py        # BaseEstimator with Template Method pattern
-│   └── estimators/    # Individual estimators (~300 lines each)
+│   ├── grm.py         # GRM data loading and adjustment
+│   ├── grm_base.py    # GRM base estimator (mortality, growth, removals)
+│   ├── variance.py    # Shared variance calculations
+│   └── estimators/    # Individual estimators
 │       ├── area.py
+│       ├── area_change.py
 │       ├── biomass.py
+│       ├── carbon_pools.py
 │       ├── growth.py
 │       ├── mortality.py
+│       ├── panel.py
+│       ├── removals.py
+│       ├── site_index.py
 │       ├── tpa.py
+│       ├── tree_metrics.py
 │       └── volume.py
 ├── filtering/          # Domain filtering and indicators
 │   ├── core/parser.py # Centralized domain expression parser
 │   ├── tree/filters.py
 │   ├── area/filters.py
 │   └── indicators/    # Land type classification
+├── evalidator/         # EVALIDator API client for validation
+├── downloader/         # FIA data download from DataMart
+├── validation.py       # Input validation utilities
+├── utils/              # Reference table helpers
 └── constants/          # FIA constants and standard values
 ```
 
@@ -71,7 +85,7 @@ pyfia/
 - Key methods: `clip_by_evalid()`, `clip_by_state()`, `clip_most_recent()`
 
 **Estimation Functions**
-- Simple API: `area()`, `biomass()`, `volume()`, `tpa()`, `mortality()`, `growth()`
+- Simple API: `area()`, `biomass()`, `volume()`, `tpa()`, `mortality()`, `growth()`, `removals()`, `area_change()`, `site_index()`, `tree_metrics()`, `carbon_pools()`
 - All support domain filtering, grouping, variance calculations
 - BaseEstimator uses Template Method for consistent workflow
 
@@ -109,12 +123,13 @@ pyfia/
 > Full details in [fia_technical_context.md](./fia_technical_context.md)
 
 ### EVALID System
-6-digit codes (SSYYTT) for statistically valid plot groupings.
+Codes in SSYYTT format for statistically valid plot groupings.
+Note: state codes with single-digit FIPS (e.g., AL=1) produce 5-digit EVALIDs.
 
 ```python
 with FIA("data/nfi_south.duckdb") as db:
-    db.clip_by_state(37)                    # North Carolina
-    db.clip_most_recent(eval_type="EXPVOL") # Most recent volume evaluation
+    db.clip_by_state(37)                   # North Carolina
+    db.clip_most_recent(eval_type="VOL")   # Most recent volume evaluation
     results = volume(db)
 ```
 

--- a/docs/specs/pyfia-differentiation-docs.md
+++ b/docs/specs/pyfia-differentiation-docs.md
@@ -44,7 +44,7 @@ FIA data is organized into **evaluation groups (EVALIDs)**—6-digit codes that 
 ```python
 with FIA(db_path) as db:
     db.clip_by_state(37)  # North Carolina
-    db.clip_most_recent(eval_type="EXPVOL")  # Most recent volume evaluation
+    db.clip_most_recent(eval_type="VOL")  # Most recent volume evaluation
     result = volume(db)
 ```
 
@@ -231,7 +231,7 @@ from pyfia import FIA, area, volume, tpa, biomass
 with FIA(db_path) as db:
     # Filter to state and most recent evaluation
     db.clip_by_state("NC")
-    db.clip_most_recent(eval_type="EXPVOL")
+    db.clip_most_recent(eval_type="VOL")
     
     # Forest area
     area_result = area(db, land_type="forest")


### PR DESCRIPTION
## Summary
- Fix `eval_type="EXPVOL"` to `eval_type="VOL"` in README, DEVELOPMENT.md, and specs — the code adds the `EXP` prefix internally, so passing `"EXPVOL"` would search for `"EXPEXPVOL"`
- Update module structure in DEVELOPMENT.md to include all 11 estimators and 3 missing modules (`evalidator`, `validation`, `utils`)
- Update CLAUDE.md project structure to match actual layout
- Add note about variable-width EVALIDs for single-digit FIPS codes

## Test plan
- [x] 720 unit tests pass
- [x] Documentation-only changes, no code impact