### PR TITLE
fix(security): coerce clip_by_state/clip_by_evalid args to int (#87)

### DIFF
--- a/src/pyfia/core/fia.py
+++ b/src/pyfia/core/fia.py
@@ -550,8 +550,18 @@ class FIA:
         FIA
             Self for method chaining.
         """
-        if isinstance(evalid, int):
+        # Normalize to a list and coerce to int. The type contract is
+        # int | list[int]; coercing here enforces it and neutralizes any
+        # untrusted value before it reaches the f-string IN (...) clause.
+        if not isinstance(evalid, (list, tuple)):
             evalid = [evalid]
+        try:
+            evalid = [int(e) for e in evalid]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"clip_by_evalid expects an int or list of ints; "
+                f"got an invalid EVALID value ({exc})"
+            ) from exc
 
         self.evalid = evalid
         # Clear plot CN caches when EVALID changes
@@ -590,8 +600,18 @@ class FIA:
         FIA
             Self for method chaining.
         """
-        if isinstance(state, int):
+        # Normalize to a list and coerce to int. The type contract is
+        # int | list[int]; coercing here enforces it and neutralizes any
+        # untrusted value before it reaches the f-string IN (...) clause.
+        if not isinstance(state, (list, tuple)):
             state = [state]
+        try:
+            state = [int(s) for s in state]
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"clip_by_state expects an int or list of ints; "
+                f"got an invalid state code ({exc})"
+            ) from exc
 
         self.state_filter = state
 

--- a/tests/unit/test_clip_int_coercion.py
+++ b/tests/unit/test_clip_int_coercion.py
@@ -1,0 +1,66 @@
+"""Unit tests for int coercion in clip_by_evalid / clip_by_state (#87).
+
+The clip methods are typed ``int | list[int]`` but historically did no
+coercion, so a non-int value would flow raw into an f-string ``IN (...)``
+clause. Coercing to int enforces the contract and neutralizes any untrusted
+value (e.g. ``"37 OR 1=1"`` raises instead of being interpolated).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_fia():
+    """A FIA instance without a real database connection."""
+    from pyfia.core.fia import FIA
+
+    with patch.object(FIA, "__init__", lambda self: None):
+        db = FIA()
+        db.tables = {}
+        db.evalid = None
+        db.state_filter = None
+        db._valid_plot_cns = None
+        db._spatial_plot_cns = None
+        db._reader = MagicMock()
+        return db
+
+
+class TestClipByEvalidCoercion:
+    def test_single_int(self, mock_fia):
+        mock_fia.clip_by_evalid(132401)
+        assert mock_fia.evalid == [132401]
+
+    def test_list_of_ints(self, mock_fia):
+        mock_fia.clip_by_evalid([132401, 132301])
+        assert mock_fia.evalid == [132401, 132301]
+
+    def test_numeric_string_is_coerced(self, mock_fia):
+        mock_fia.clip_by_evalid("132401")
+        assert mock_fia.evalid == [132401]
+        assert all(isinstance(e, int) for e in mock_fia.evalid)
+
+    def test_mixed_list_coerced_to_int(self, mock_fia):
+        mock_fia.clip_by_evalid([132401, "132301"])
+        assert mock_fia.evalid == [132401, 132301]
+
+    def test_injection_attempt_rejected(self, mock_fia):
+        with pytest.raises(ValueError, match="clip_by_evalid"):
+            mock_fia.clip_by_evalid("132401 OR 1=1")
+        # Nothing should have been stored from the bad call.
+        assert mock_fia.evalid is None
+
+
+class TestClipByStateCoercion:
+    def test_bad_value_rejected_before_db_access(self, mock_fia):
+        with patch.object(mock_fia, "find_evalid") as find:
+            with pytest.raises(ValueError, match="clip_by_state"):
+                mock_fia.clip_by_state("37; DROP TABLE PLOT")
+            find.assert_not_called()
+
+    def test_numeric_inputs_coerced(self, mock_fia):
+        with patch.object(mock_fia, "find_evalid", return_value=[]):
+            mock_fia.clip_by_state(["37", 13])
+        assert mock_fia.state_filter == [37, 13]
+        assert all(isinstance(s, int) for s in mock_fia.state_filter)


### PR DESCRIPTION
Partial fix for #87 — the int-coercion piece (the cheap, high-confidence part).

## Problem
`clip_by_state` / `clip_by_evalid` are typed `int | list[int]` but performed no coercion — they only wrapped a scalar in a list, then the values were interpolated raw into `STATECD IN (...)` / `EVALID IN (...)` f-strings. If those values ever come from untrusted input, that's a SQL-injection seam.

## Change
- Normalize any scalar (int/str/…) to a list, then coerce every element with `int()`.
- Raise a clear `ValueError` on non-numeric input (e.g. `"37 OR 1=1"`, `"37; DROP TABLE PLOT"`) **before** any DB access or SQL construction.
- Numeric strings like `"37"` are coerced to `37` (lenient, enforces the contract).

## Tests
New `tests/unit/test_clip_int_coercion.py` (7 cases): int / list / numeric-string coercion, mixed lists, injection-attempt rejection, and that a bad `clip_by_state` value raises before `find_evalid` is ever called. All green; ruff + mypy clean.

## Still open in #87 (not in this PR)
- Binding the IN-lists as DuckDB parameters instead of f-string interpolation.
- Making `DomainExpressionParser` (allowlist) the primary WHERE-clause gate over the keyword denylist.

Milestone: 1.4.0
