### PR TITLE
fix(downloader): atomic writes + cache integrity verification (#88)

### DIFF
--- a/src/pyfia/downloader/cache.py
+++ b/src/pyfia/downloader/cache.py
@@ -7,6 +7,7 @@ FIA data that has already been retrieved.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from dataclasses import asdict, dataclass
@@ -107,12 +108,28 @@ class DownloadCache:
             self._metadata = {}
 
     def _save_metadata(self) -> None:
-        """Save metadata to disk."""
+        """Save metadata to disk atomically (temp file + replace)."""
         data = {k: asdict(v) for k, v in self._metadata.items()}
-        with open(self.metadata_file, "w") as f:
+        tmp_file = self.metadata_file.with_name(self.metadata_file.name + ".tmp")
+        with open(tmp_file, "w") as f:
             json.dump(data, f, indent=2)
+        tmp_file.replace(self.metadata_file)
 
-    def get_cached(self, state: str, max_age_days: float | None = None) -> Path | None:
+    @staticmethod
+    def _compute_checksum(path: Path) -> str:
+        """Compute the MD5 checksum of a file."""
+        md5 = hashlib.md5()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    def get_cached(
+        self,
+        state: str,
+        max_age_days: float | None = None,
+        verify_checksum: bool = False,
+    ) -> Path | None:
         """
         Get the path to a cached DuckDB file if it exists and is valid.
 
@@ -123,6 +140,9 @@ class DownloadCache:
         max_age_days : float, optional
             Maximum age in days to consider cache valid.
             Defaults to None (no age limit).
+        verify_checksum : bool, default False
+            If True, recompute the file's MD5 and compare against the stored
+            checksum (slower for large files). File size is always checked.
 
         Returns
         -------
@@ -143,6 +163,27 @@ class DownloadCache:
             del self._metadata[key]
             self._save_metadata()
             return None
+
+        # Verify size — cheaply detects truncated/partial files (e.g. an
+        # interrupted download or conversion).
+        if cached.size_bytes and path.stat().st_size != cached.size_bytes:
+            logger.warning(
+                "Cached file size mismatch for %s (expected %d bytes, "
+                "got %d); treating as invalid.",
+                key,
+                cached.size_bytes,
+                path.stat().st_size,
+            )
+            return None
+
+        # Optional full integrity check against the stored MD5.
+        if verify_checksum and cached.checksum:
+            if self._compute_checksum(path) != cached.checksum:
+                logger.warning(
+                    "Cached file checksum mismatch for %s; treating as invalid.",
+                    key,
+                )
+                return None
 
         # Check age if specified
         if max_age_days is not None and cached.age_days > max_age_days:
@@ -177,13 +218,7 @@ class DownloadCache:
 
         # Calculate checksum if not provided
         if checksum is None:
-            import hashlib
-
-            md5 = hashlib.md5()
-            with open(path, "rb") as f:
-                for chunk in iter(lambda: f.read(8192), b""):
-                    md5.update(chunk)
-            checksum = md5.hexdigest()
+            checksum = self._compute_checksum(path)
 
         cached = CachedDownload(
             state=state.upper(),

--- a/src/pyfia/downloader/client.py
+++ b/src/pyfia/downloader/client.py
@@ -160,32 +160,47 @@ class DataMartClient:
                 # Ensure parent directory exists
                 dest_path.parent.mkdir(parents=True, exist_ok=True)
 
-                if show_progress and total_size > 0:
-                    with Progress(
-                        SpinnerColumn(),
-                        TextColumn("[bold blue]{task.description}"),
-                        BarColumn(),
-                        DownloadColumn(),
-                        TransferSpeedColumn(),
-                        TimeRemainingColumn(),
-                    ) as progress:
-                        task = progress.add_task(
-                            description or dest_path.name, total=total_size
-                        )
+                # Download to a temporary file in the same directory, then
+                # atomically move it into place. A crash or network interrupt
+                # mid-stream leaves the .part file behind, never a truncated
+                # file at the canonical path that downstream code would treat
+                # as complete.
+                tmp_path = dest_path.with_name(dest_path.name + ".part")
+                try:
+                    if show_progress and total_size > 0:
+                        with Progress(
+                            SpinnerColumn(),
+                            TextColumn("[bold blue]{task.description}"),
+                            BarColumn(),
+                            DownloadColumn(),
+                            TransferSpeedColumn(),
+                            TimeRemainingColumn(),
+                        ) as progress:
+                            task = progress.add_task(
+                                description or dest_path.name, total=total_size
+                            )
 
-                        with open(dest_path, "wb") as f:
+                            with open(tmp_path, "wb") as f:
+                                for chunk in response.iter_content(
+                                    chunk_size=self.chunk_size
+                                ):
+                                    if chunk:
+                                        f.write(chunk)
+                                        progress.update(task, advance=len(chunk))
+                    else:
+                        # No progress bar (small file or progress disabled)
+                        with open(tmp_path, "wb") as f:
                             for chunk in response.iter_content(
                                 chunk_size=self.chunk_size
                             ):
                                 if chunk:
                                     f.write(chunk)
-                                    progress.update(task, advance=len(chunk))
-                else:
-                    # No progress bar (small file or progress disabled)
-                    with open(dest_path, "wb") as f:
-                        for chunk in response.iter_content(chunk_size=self.chunk_size):
-                            if chunk:
-                                f.write(chunk)
+
+                    tmp_path.replace(dest_path)
+                except BaseException:
+                    # Clean up the partial file on any failure or interrupt.
+                    tmp_path.unlink(missing_ok=True)
+                    raise
 
                 logger.debug(f"Downloaded {url} to {dest_path}")
                 return dest_path

--- a/tests/unit/test_cache_integrity.py
+++ b/tests/unit/test_cache_integrity.py
@@ -1,0 +1,112 @@
+"""Unit tests for cache atomicity and integrity verification (#88).
+
+Covers atomic metadata writes, size/checksum verification in get_cached(),
+and atomic download writes (temp file + replace, with cleanup on failure).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyfia.downloader.cache import DownloadCache
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return DownloadCache(tmp_path / "cache")
+
+
+def _make_file(path, data: bytes = b"duckdb-bytes"):
+    path.write_bytes(data)
+    return path
+
+
+class TestGetCachedIntegrity:
+    def test_valid_file_returned(self, cache, tmp_path):
+        f = _make_file(tmp_path / "GA.duckdb")
+        cache.add_to_cache("GA", f)
+        assert cache.get_cached("GA") == f
+
+    def test_size_mismatch_treated_as_invalid(self, cache, tmp_path):
+        f = _make_file(tmp_path / "GA.duckdb", b"original-content")
+        cache.add_to_cache("GA", f)
+        # Truncate the file behind the cache's back (simulates partial write).
+        f.write_bytes(b"short")
+        assert cache.get_cached("GA") is None
+
+    def test_checksum_mismatch_with_verify(self, cache, tmp_path):
+        f = _make_file(tmp_path / "GA.duckdb", b"original-content")
+        cache.add_to_cache("GA", f)
+        # Same length, different content — only a checksum check catches this.
+        f.write_bytes(b"corrupted-conten")
+        assert len(b"corrupted-conten") == len(b"original-content")
+        assert cache.get_cached("GA", verify_checksum=True) is None
+        # Without checksum verification the size check passes it through.
+        assert cache.get_cached("GA") == f
+
+
+class TestAtomicMetadataWrite:
+    def test_metadata_is_valid_json_and_no_tmp_left(self, cache, tmp_path):
+        f = _make_file(tmp_path / "GA.duckdb")
+        cache.add_to_cache("GA", f)
+        # Metadata file exists, parses, and no .tmp sidecar remains.
+        assert cache.metadata_file.exists()
+        json.loads(cache.metadata_file.read_text())
+        assert not cache.metadata_file.with_name(
+            cache.metadata_file.name + ".tmp"
+        ).exists()
+
+    def test_metadata_reloads_in_new_instance(self, cache, tmp_path):
+        f = _make_file(tmp_path / "GA.duckdb")
+        cache.add_to_cache("GA", f)
+        reloaded = DownloadCache(cache.cache_dir)
+        assert reloaded.get_cached("GA") == f
+
+
+class TestAtomicDownload:
+    def _client(self):
+        from pyfia.downloader.client import DataMartClient
+
+        client = DataMartClient()
+        client.session = MagicMock()
+        return client
+
+    def _response(self, chunks, status=200):
+        resp = MagicMock()
+        resp.status_code = status
+        resp.headers = {"content-length": str(sum(len(c) for c in chunks))}
+        resp.raise_for_status = MagicMock()
+        resp.iter_content = MagicMock(return_value=iter(chunks))
+        return resp
+
+    def test_successful_download_writes_dest_no_part(self, tmp_path):
+        client = self._client()
+        client.session.get.return_value = self._response([b"abc", b"def"])
+        dest = tmp_path / "TREE.csv"
+        out = client._download_file("http://example/TREE.csv", dest, show_progress=False)
+        assert out == dest
+        assert dest.read_bytes() == b"abcdef"
+        assert not dest.with_name("TREE.csv.part").exists()
+
+    def test_interrupted_download_leaves_no_dest_or_part(self, tmp_path):
+        client = self._client()
+
+        def boom():
+            yield b"abc"
+            raise ConnectionError("connection dropped")
+
+        resp = self._response([])
+        resp.iter_content = MagicMock(return_value=boom())
+        # max_retries defaults >1; force a single attempt so the error surfaces.
+        client.max_retries = 1
+        client.session.get.return_value = resp
+
+        dest = tmp_path / "TREE.csv"
+        with pytest.raises(Exception):
+            client._download_file("http://example/TREE.csv", dest, show_progress=False)
+        # Neither a truncated dest nor a leftover .part file should remain.
+        assert not dest.exists()
+        assert not dest.with_name("TREE.csv.part").exists()


### PR DESCRIPTION
Closes #88.

## Problem
- Downloads wrote straight to the final path — a crash/interrupt mid-stream left a truncated file that downstream code treated as complete.
- `DownloadCache._save_metadata()` wrote JSON in place — a crash mid-write corrupted the cache index.
- The stored MD5 `checksum` was computed at `add_to_cache` but **never verified** — `get_cached()` only checked existence + age.

## Change
- **`_download_file`**: download to a sibling `*.part` file, then `Path.replace()` it into place atomically; remove the `.part` on any failure/interrupt (`except BaseException`).
- **`_save_metadata`**: write to `*.tmp`, then `replace()` — atomic, no partial JSON.
- **`get_cached`**: always verify file **size** (cheap; catches truncated files) and added opt-in `verify_checksum=True` for a full MD5 check. Extracted `_compute_checksum` and reused it in `add_to_cache`.

## Tests
New `tests/unit/test_cache_integrity.py` (7 cases): valid hit, size-mismatch → invalid, checksum-mismatch (same length) caught only with `verify_checksum=True`, atomic metadata (valid JSON, no `.tmp` left, reloads in a fresh instance), successful download leaves no `.part`, and an interrupted download leaves **neither** a truncated dest nor a `.part`. All green; ruff + mypy clean.

Cross-reference: current practice is temp-file + `os.replace` for atomic writes ([Python os.replace](https://thelinuxcode.com/python-osreplace-for-safe-atomic-file-updates-in-real-systems/)).

Milestone: 1.4.0
