### PR TITLE
fix: derive __version__ from package metadata (#92)

### DIFF
--- a/src/pyfia/__init__.py
+++ b/src/pyfia/__init__.py
@@ -7,7 +7,16 @@ Analysis (FIA) data using modern data science tools like Polars and DuckDB.
 
 from __future__ import annotations
 
-__version__ = "1.4.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
+
+# Single source of truth for the version is pyproject.toml; read it from the
+# installed package metadata so the two can never drift apart.
+try:
+    __version__ = _version("pyfia")
+except PackageNotFoundError:  # pragma: no cover - running from an uninstalled tree
+    __version__ = "0.0.0+unknown"
+
 __author__ = "Chris Mihiar"
 
 # Core exports - Main functionality

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,16 @@
+"""Version is sourced from package metadata, not hardcoded (#92)."""
+
+from importlib.metadata import version
+
+import pyfia
+
+
+def test_version_is_nonempty_string():
+    assert isinstance(pyfia.__version__, str)
+    assert pyfia.__version__
+
+
+def test_version_matches_installed_metadata():
+    # __version__ must track the installed distribution version (pyproject),
+    # never a separately-maintained string that can drift.
+    assert pyfia.__version__ == version("pyfia")


### PR DESCRIPTION
Addresses the **version-drift** item in #92 (the highest-value one for release hygiene).

## Problem
`__version__` was hardcoded in `src/pyfia/__init__.py` and duplicated the `pyproject.toml` version. They drifted — both read `1.3.0` while `main` was 64 commits past the published 1.3.0. That dual-source string is exactly what let the release version go stale unnoticed.

## Change
Derive `__version__` from `importlib.metadata.version("pyfia")` so `pyproject.toml` is the single source of truth. Falls back to `"0.0.0+unknown"` when imported from an uninstalled source tree.

## Tests
New `tests/unit/test_version.py`: `__version__` is a non-empty string and equals `importlib.metadata.version("pyfia")`. Green; ruff + mypy clean.

## ⚠️ Merge-order note
This edits the same `__init__.py` line as the release PR #93 (which bumps the hardcoded string to `1.4.0`). Expect a 1-line conflict — resolve by **keeping this metadata-based version** (drop #93's `__init__.py` hunk; #93's `pyproject.toml`/`uv.lock` bump to 1.4.0 is what then drives `__version__`). Cleanest is to merge #93 first, then rebase this.

## Remaining in #92 (separate follow-up)
Column-name literals → constants, `assert`→explicit raise, degraded-mode log levels, `ignore_errors` row-count logging, variance single-plot comment.

Milestone: 1.4.0
