### PR TITLE
fix(downloader): guard against caching a DB missing reference tables (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ public APIs from 1.3.0 remain backward compatible.
 - **Woodland-species biomass collapse** in the `live_tree()` NSVB path; **woodland-species zeroing** in `standing_dead()`; both share a guard via the carbon estimator base class.
 - DECAYCD empty-string filter leak in the standing-dead path.
 - **Non-atomic file writes** in the downloader (#88) — downloads now write to a temporary file and atomically replace the destination (with cleanup on interrupt), and cache metadata is written the same way; an interrupted download/write no longer leaves a truncated file. `get_cached()` now verifies file size on every hit and supports opt-in MD5 verification (the stored checksum was previously never checked).
+- **Silently cached broken databases on reference-table download failure** (#86) — `download()` now verifies the built database contains the required reference tables (`REF_SPECIES`, `REF_FOREST_TYPE`, `REF_STATE`) before caching. If any are missing/empty the incomplete database is discarded and a clear `DownloadError` is raised telling the user to retry, instead of caching a database that breaks `by_species` / name-join operations.
 
 ### Security
 - **`clip_by_state()` / `clip_by_evalid()` now coerce arguments to `int`** (#87) — enforces the documented `int | list[int]` contract and rejects non-numeric input (e.g. `"37 OR 1=1"`) before it reaches the SQL `IN (...)` clause, closing a string-interpolation seam.

--- a/src/pyfia/downloader/__init__.py
+++ b/src/pyfia/downloader/__init__.py
@@ -62,6 +62,11 @@ from pyfia.validation import sanitize_sql_path, validate_sql_identifier
 logger = logging.getLogger(__name__)
 console = Console()
 
+# Reference tables required for species / forest-type / state name resolution
+# (e.g. by_species=True, join_*_names()). A built database missing any of
+# these is treated as a failed download rather than silently cached (#86).
+REQUIRED_REFERENCE_TABLES = ("REF_SPECIES", "REF_FOREST_TYPE", "REF_STATE")
+
 __all__ = [
     # Main function
     "download",
@@ -94,6 +99,65 @@ def _get_default_data_dir() -> Path:
     from pyfia.core.settings import settings
 
     return settings.cache_dir.parent / "data"
+
+
+def _missing_reference_tables(db_path: Path) -> list[str]:
+    """Return required reference tables absent or empty in a built database.
+
+    Used to detect a database that was assembled after a failed reference-table
+    download, so it is never silently cached as valid (#86).
+
+    Parameters
+    ----------
+    db_path : Path
+        Path to the built DuckDB database.
+
+    Returns
+    -------
+    list of str
+        Names of required reference tables that are missing or empty. Empty
+        list means all required reference tables are present and non-empty.
+    """
+    import duckdb
+
+    missing: list[str] = []
+    conn = duckdb.connect(str(db_path), read_only=True)
+    try:
+        existing = {
+            row[0].upper()
+            for row in conn.execute(
+                "SELECT table_name FROM information_schema.tables"
+            ).fetchall()
+        }
+        for table in REQUIRED_REFERENCE_TABLES:
+            if table.upper() not in existing:
+                missing.append(table)
+                continue
+            count = conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()
+            if not count or not count[0]:
+                missing.append(table)
+    finally:
+        conn.close()
+    return missing
+
+
+def _verify_reference_tables_or_discard(db_path: Path, label: str) -> None:
+    """Raise (and delete ``db_path``) if required reference tables are missing.
+
+    A failed reference-table download must not produce a database that is
+    cached and later breaks ``by_species`` / name-join operations. The partial
+    database is removed so a retry rebuilds it cleanly.
+    """
+    missing = _missing_reference_tables(db_path)
+    if missing:
+        db_path.unlink(missing_ok=True)
+        raise DownloadError(
+            f"Reference tables missing from the downloaded database for "
+            f"{label}: {', '.join(missing)}. This usually means the "
+            f"reference-table download failed (check network / DataMart "
+            f"availability). The incomplete database was discarded; "
+            f"please retry the download."
+        )
 
 
 def _convert_csvs_to_duckdb(
@@ -389,10 +453,12 @@ def _download_single_state(
         try:
             client.download_reference_tables(
                 dest_dir=csv_dir,
-                tables=["REF_SPECIES", "REF_FOREST_TYPE", "REF_STATE"],
+                tables=list(REQUIRED_REFERENCE_TABLES),
                 show_progress=show_progress,
             )
         except Exception as e:
+            # Logged here for the root cause; the post-build verification below
+            # is what makes a missing-reference-table build fatal (#86).
             logger.warning(f"Failed to download reference tables: {e}")
 
         # Convert to DuckDB
@@ -409,6 +475,10 @@ def _download_single_state(
         _convert_csvs_to_duckdb(
             csv_dir, duckdb_path, state_code=state_code, show_progress=show_progress
         )
+
+    # Fail loudly (and discard) rather than caching a database that is missing
+    # its reference tables.
+    _verify_reference_tables_or_discard(duckdb_path, state)
 
     if use_cache:
         cache.add_to_cache(state, duckdb_path)
@@ -558,7 +628,7 @@ def _download_multi_state(
                 ref_temp_path = Path(ref_temp_dir)
                 ref_tables = client.download_reference_tables(
                     dest_dir=ref_temp_path,
-                    tables=["REF_SPECIES", "REF_FOREST_TYPE", "REF_STATE"],
+                    tables=list(REQUIRED_REFERENCE_TABLES),
                     show_progress=show_progress,
                 )
 
@@ -581,6 +651,10 @@ def _download_multi_state(
 
     finally:
         conn.close()
+
+    # Fail loudly (and discard) rather than caching a database that is missing
+    # its reference tables.
+    _verify_reference_tables_or_discard(output_path, cache_key)
 
     if use_cache:
         cache.add_to_cache(cache_key, output_path)

--- a/tests/unit/test_reference_table_guard.py
+++ b/tests/unit/test_reference_table_guard.py
@@ -1,0 +1,71 @@
+"""Reference-table integrity guard for downloaded databases (#86).
+
+A failed reference-table download must not silently produce — and cache — a
+database missing REF_SPECIES / REF_FOREST_TYPE / REF_STATE.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from pyfia.downloader import (
+    REQUIRED_REFERENCE_TABLES,
+    _missing_reference_tables,
+    _verify_reference_tables_or_discard,
+)
+from pyfia.downloader.exceptions import DownloadError
+
+
+def _make_db(path, table_rows: dict[str, int]):
+    """Create a DuckDB file with the given reference tables and row counts."""
+    conn = duckdb.connect(str(path))
+    try:
+        for name, n in table_rows.items():
+            # CTAS from range(n): table always exists; n=0 -> empty table.
+            conn.execute(f'CREATE TABLE "{name}" AS SELECT * FROM range({n})')
+    finally:
+        conn.close()
+    return path
+
+
+def _full_db(path):
+    return _make_db(path, {t: 3 for t in REQUIRED_REFERENCE_TABLES})
+
+
+class TestMissingReferenceTables:
+    def test_none_missing_when_all_present(self, tmp_path):
+        db = _full_db(tmp_path / "ga.duckdb")
+        assert _missing_reference_tables(db) == []
+
+    def test_absent_table_reported(self, tmp_path):
+        db = _make_db(
+            tmp_path / "ga.duckdb",
+            {"REF_SPECIES": 3, "REF_FOREST_TYPE": 3},  # REF_STATE absent
+        )
+        assert _missing_reference_tables(db) == ["REF_STATE"]
+
+    def test_empty_table_reported(self, tmp_path):
+        db = _make_db(
+            tmp_path / "ga.duckdb",
+            {"REF_SPECIES": 3, "REF_FOREST_TYPE": 3, "REF_STATE": 0},
+        )
+        assert _missing_reference_tables(db) == ["REF_STATE"]
+
+
+class TestVerifyOrDiscard:
+    def test_passes_silently_when_complete(self, tmp_path):
+        db = _full_db(tmp_path / "ga.duckdb")
+        _verify_reference_tables_or_discard(db, "GA")  # no raise
+        assert db.exists()
+
+    def test_raises_and_discards_when_incomplete(self, tmp_path):
+        db = _make_db(tmp_path / "ga.duckdb", {"REF_SPECIES": 3})
+        with pytest.raises(DownloadError) as exc:
+            _verify_reference_tables_or_discard(db, "GA")
+        msg = str(exc.value)
+        assert "REF_FOREST_TYPE" in msg and "REF_STATE" in msg
+        assert "GA" in msg
+        assert "retry" in msg.lower()
+        # Partial database is removed so a retry rebuilds cleanly.
+        assert not db.exists()


### PR DESCRIPTION
Closes #86.

## Problem
In `download()` (and `_download_multi_state()`), a failed reference-table download was caught, logged at `warning`, and then the build proceeded to `_convert_csvs_to_duckdb()` + `cache.add_to_cache()`. Result: a DuckDB **missing `REF_SPECIES` / `REF_FOREST_TYPE` / `REF_STATE`** was built and **cached as valid**, silently breaking `by_species=True` and `join_*_names()` — and persisting across runs because it was cached.

## Change
- New `_missing_reference_tables(db_path)` — opens the built DB read-only and returns required reference tables that are absent or empty (case-insensitive existence check).
- New `_verify_reference_tables_or_discard(db_path, label)` — if any are missing, **delete the partial DB** (so a retry rebuilds cleanly) and raise a clear `DownloadError` telling the user to retry. Called in **both** the single-state and multi-state paths, immediately before `add_to_cache`.
- Add `REQUIRED_REFERENCE_TABLES` constant and reuse it for the `download_reference_tables` calls (DRY).

Behavior change: a download that can't obtain reference tables now **fails loudly** rather than producing a half-broken cached database. Core estimation data download still works; only the (previously silent) missing-reference-table case is now fatal.

## Tests
New `tests/unit/test_reference_table_guard.py` (5 cases): all-present → no missing / no raise / file kept; absent table reported; empty (0-row) table reported; verify raises `DownloadError` (mentions the missing tables, the label, and "retry") and **discards** the partial file. Full unit suite: 945 passed; ruff + mypy clean.

Milestone: 1.4.0
