### PR TITLE
ci: add PyPI Trusted Publishing workflow (OIDC, tokenless)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish to PyPI
+
+# Publishes to PyPI via Trusted Publishing (OIDC) — no API token required.
+# Triggered when a GitHub Release is published. The release tag's version must
+# match the version in pyproject.toml (e.g. release on tag v1.4.0 -> pyfia 1.4.0).
+#
+# One-time PyPI setup required before the first run: register a Trusted
+# Publisher for the `pyfia` project (Manage project -> Publishing) pointing at
+# owner `mihiarc`, repo `pyfia`, workflow `publish.yml`, environment `pypi`.
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Verify built version matches the release tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          if [ ! -f "dist/pyfia-${tag}.tar.gz" ]; then
+            echo "::error::Release tag '${GITHUB_REF_NAME}' does not match the built version."
+            echo "Built artifacts:" && ls -1 dist/
+            exit 1
+          fi
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyfia
+    permissions:
+      id-token: write  # REQUIRED for Trusted Publishing (OIDC); no token needed
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Adds **PyPI Trusted Publishing** (OIDC) so releases publish without any stored API token.

## What this does
- New `.github/workflows/publish.yml`, triggered on **GitHub Release published**.
- **build** job: `uv build`, then verifies the built version matches the release tag (guards against tag/`pyproject` mismatch), uploads `dist/` as an artifact.
- **publish** job: downloads `dist/`, runs `pypa/gh-action-pypi-publish@release/v1` with job-level `id-token: write` and a `pypi` environment. **No username/password/token** — GitHub exchanges an OIDC token with PyPI.

## ⚠️ Required one-time PyPI setup (must be done before the first release run)
On PyPI → **`pyfia` project → Manage → Publishing → Add a new publisher (GitHub)**:
- Owner: `mihiarc`
- Repository: `pyfia`
- Workflow name: `publish.yml`
- Environment name: `pypi`

(Existing project, so use the project's *Publishing* tab — not the "pending publisher" flow.)

## How a release then works
1. Merge this PR.
2. Register the trusted publisher on PyPI (above).
3. Create a GitHub Release on a tag whose version matches `pyproject.toml` → the workflow builds and publishes automatically, tokenlessly. (Creating a Release for the existing `v1.4.0` tag will publish 1.4.0.)

Sources: [PyPA action](https://github.com/pypa/gh-action-pypi-publish), [PyPI trusted publishers docs](https://docs.pypi.org/trusted-publishers/using-a-publisher/), [PyPA publishing guide](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).
