### PR TITLE
fix: GRM/COND-column cluster (#102–#106)

### DIFF
--- a/src/pyfia/core/fia.py
+++ b/src/pyfia/core/fia.py
@@ -30,6 +30,69 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Mapping of user-facing ``eval_type`` tokens to the FIA ``POP_EVAL_TYP.EVAL_TYP``
+# codes they select. Most tokens map to a single ``EXP<token>`` code. ``"GRM"`` is
+# a convenience alias for the growth/removal/mortality family: those three
+# evaluation types share one annual EVALID per state, so resolving the family and
+# taking the common most-recent EVALID gives the documented one-call ergonomics
+# (see issue #102).
+EVAL_TYPE_ALIASES: dict[str, list[str]] = {
+    "ALL": ["EXPALL"],
+    "VOL": ["EXPVOL"],
+    "GRM": ["EXPGROW", "EXPMORT", "EXPREMV"],
+    "GROW": ["EXPGROW"],
+    "MORT": ["EXPMORT"],
+    "REMV": ["EXPREMV"],
+    "CHNG": ["EXPCHNG"],
+    "DWM": ["EXPDWM"],
+    "REGEN": ["EXPREGEN"],
+    "INV": ["EXPINV"],
+    "CURR": ["EXPCURR"],
+}
+
+# All recognized raw EVAL_TYP codes, so callers may pass a code (e.g. "EXPALL")
+# directly in addition to the friendly tokens above.
+KNOWN_EVAL_TYP_CODES: frozenset[str] = frozenset(
+    code for codes in EVAL_TYPE_ALIASES.values() for code in codes
+)
+
+
+def resolve_eval_typ_codes(eval_type: str) -> list[str]:
+    """Resolve an ``eval_type`` token to its FIA ``EVAL_TYP`` code(s).
+
+    Accepts both friendly tokens (``"VOL"``, ``"GRM"``, ``"GROW"`` ...) and raw
+    ``EVAL_TYP`` codes (``"EXPVOL"`` ...). ``"GRM"`` expands to the full
+    growth/removal/mortality family.
+
+    Parameters
+    ----------
+    eval_type : str
+        Evaluation type token or raw ``EVAL_TYP`` code (case-insensitive).
+
+    Returns
+    -------
+    list of str
+        One or more ``EVAL_TYP`` codes to match against ``POP_EVAL_TYP``.
+
+    Raises
+    ------
+    ValueError
+        If the token is not a recognized evaluation type, with a message
+        listing the valid options.
+    """
+    token = eval_type.strip().upper()
+    if token in EVAL_TYPE_ALIASES:
+        return list(EVAL_TYPE_ALIASES[token])
+    if token in KNOWN_EVAL_TYP_CODES:
+        return [token]
+    valid = ", ".join(sorted(EVAL_TYPE_ALIASES))
+    raise ValueError(
+        f"Unknown eval_type {eval_type!r}. Valid options: {valid}. "
+        "Use 'GRM' for growth/removal/mortality together, or the specific "
+        "'GROW', 'MORT', or 'REMV' for a single GRM component."
+    )
+
+
 class FIA:
     """
     Main FIA database class for working with Forest Inventory and Analysis data.
@@ -410,7 +473,10 @@ class FIA:
         year : int or list of int, optional
             End inventory year(s) to filter by.
         eval_type : str, optional
-            Evaluation type ('VOL', 'GRM', 'CHNG', 'ALL', etc.).
+            Evaluation type token. One of 'ALL', 'VOL', 'GRM', 'GROW', 'MORT',
+            'REMV', 'CHNG', 'DWM', 'REGEN', 'INV', 'CURR', or a raw EVAL_TYP
+            code (e.g. 'EXPVOL'). 'GRM' is an alias for the growth/removal/
+            mortality family. Unknown tokens raise ValueError.
 
         Returns
         -------
@@ -458,13 +524,11 @@ class FIA:
             df = df.filter(pl.col("END_INVYR").is_in(year))
 
         if eval_type is not None:
-            # FIA uses 'EXP' prefix for evaluation types
-            # Special case: "ALL" maps to "EXPALL" for area estimation
-            if eval_type.upper() == "ALL":
-                eval_type_full = "EXPALL"
-            else:
-                eval_type_full = f"EXP{eval_type}"
-            df = df.filter(pl.col("EVAL_TYP") == eval_type_full)
+            # Resolve the token to its EVAL_TYP code(s). "GRM" expands to the
+            # EXPGROW/EXPMORT/EXPREMV family (which share one EVALID per state),
+            # and unknown tokens raise a helpful ValueError. See issue #102.
+            eval_typ_codes = resolve_eval_typ_codes(eval_type)
+            df = df.filter(pl.col("EVAL_TYP").is_in(eval_typ_codes))
 
         if most_recent:
             # Sort by END_INVYR from POP_EVAL to find the most recent evaluation.
@@ -639,7 +703,10 @@ class FIA:
         Parameters
         ----------
         eval_type : str, default 'VOL'
-            Evaluation type ('VOL' for volume, 'GRM' for growth, etc.).
+            Evaluation type token. 'VOL' for volume/biomass/TPA/area;
+            'GRM' for growth, removals, and mortality together (or the
+            component-specific 'GROW', 'MORT', 'REMV'); 'CHNG' for change.
+            See find_evalid for the full list of accepted tokens.
 
         Returns
         -------

--- a/src/pyfia/estimation/base.py
+++ b/src/pyfia/estimation/base.py
@@ -676,7 +676,13 @@ class BaseEstimator(ABC):
         # Step 2: Aggregate to plot level
         plot_level_cols = ["PLT_CN", "STRATUM_CN", "EXPNS"]
         plot_level_cols = [c for c in plot_level_cols if c in plot_cond_data.columns]
-        plot_level_cols.extend([c for c in group_cols if c in plot_cond_data.columns and c not in plot_level_cols])
+        plot_level_cols.extend(
+            [
+                c
+                for c in group_cols
+                if c in plot_cond_data.columns and c not in plot_level_cols
+            ]
+        )
 
         plot_data = plot_cond_data.group_by(plot_level_cols).agg(
             [
@@ -823,6 +829,11 @@ class BaseEstimator(ABC):
             Results with variance columns added
         """
         if valid_group_cols:
+            from .variance import align_join_key_dtypes
+
+            # Align all-null group keys so a Null-typed key cannot break the
+            # join against the typed results key (#105).
+            variance_df = align_join_key_dtypes(results, variance_df, valid_group_cols)
             return results.join(variance_df, on=valid_group_cols, how="left")
         else:
             # No grouping - just add the single variance row's columns
@@ -1002,7 +1013,11 @@ class BaseEstimator(ABC):
             plot_level_cols.insert(1, "STRATUM_CN")
         if group_cols:
             plot_level_cols.extend(
-                [c for c in group_cols if c in plot_cond_data.columns and c not in plot_level_cols]
+                [
+                    c
+                    for c in group_cols
+                    if c in plot_cond_data.columns and c not in plot_level_cols
+                ]
             )
 
         # Build plot-level aggregation
@@ -1148,12 +1163,18 @@ class BaseEstimator(ABC):
 
         # Join variance results back to main results
         if variance_results:
+            from .variance import align_join_key_dtypes
+
             var_df = pl.DataFrame(variance_results)
             # Use only valid group columns that exist in both dataframes
             join_cols = [
                 c for c in group_cols if c in var_df.columns and c in results.columns
             ]
             if join_cols:
+                # Align all-null group keys so a Null-typed key (e.g. a
+                # disturbance code null across every group) does not break the
+                # join against the typed results key (#105).
+                var_df = align_join_key_dtypes(results, var_df, join_cols)
                 results = results.join(var_df, on=join_cols, how="left")
 
         return results

--- a/src/pyfia/estimation/columns.py
+++ b/src/pyfia/estimation/columns.py
@@ -73,6 +73,84 @@ PLOT_GROUPING_COLUMNS = [
 ]
 
 
+def collect_referenced_columns(
+    grp_by: str | list[str] | None,
+    area_domain: str | None = None,
+    tree_domain: str | None = None,
+) -> list[str]:
+    """Collect every column a user referenced via grp_by and domain filters.
+
+    Returns a de-duplicated, order-preserving list of column names drawn from
+    ``grp_by`` plus any columns referenced in ``area_domain`` / ``tree_domain``.
+    Callers route these to the table that actually holds each column (via
+    :func:`columns_in_table`) so that grouping and domain filtering resolve
+    consistently across estimators (issues #103 and #104).
+
+    Parameters
+    ----------
+    grp_by : str or list[str], optional
+        User-specified grouping column(s).
+    area_domain : str, optional
+        SQL-like area/condition filter expression.
+    tree_domain : str, optional
+        SQL-like tree filter expression.
+
+    Returns
+    -------
+    list[str]
+        Unique column names referenced by the user, in first-seen order.
+    """
+    # Local import avoids a module-load cycle (filtering imports estimation).
+    from ..filtering.parser import DomainExpressionParser
+
+    cols: list[str] = []
+    if grp_by:
+        cols.extend([grp_by] if isinstance(grp_by, str) else list(grp_by))
+    for expr in (area_domain, tree_domain):
+        if expr:
+            cols.extend(DomainExpressionParser.extract_columns(expr))
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for col in cols:
+        if col and col not in seen:
+            seen.add(col)
+            out.append(col)
+    return out
+
+
+def columns_in_table(db, table_name: str, candidates: list[str]) -> list[str]:
+    """Return the subset of ``candidates`` that exist in ``table_name``'s schema.
+
+    Used to schema-route user-referenced columns into the correct table load.
+    Falls back to returning all candidates when the schema cannot be read
+    (e.g. a mock database in unit tests), preserving prior best-effort behavior.
+
+    Parameters
+    ----------
+    db : FIA
+        Database connection exposing ``_reader.get_table_schema``.
+    table_name : str
+        Name of the table whose schema to check (e.g. "COND", "TREE", "PLOT").
+    candidates : list[str]
+        Column names to test for membership.
+
+    Returns
+    -------
+    list[str]
+        Candidates present in the table schema (order preserved), or all
+        candidates if the schema is unavailable.
+    """
+    try:
+        schema = db._reader.get_table_schema(table_name)
+        if not isinstance(schema, dict):
+            return list(candidates)
+        names = set(schema.keys())
+    except (AttributeError, TypeError, KeyError):
+        return list(candidates)
+    return [c for c in candidates if c in names]
+
+
 def get_tree_columns(
     estimator_cols: list[str],
     grp_by: str | list[str] | None = None,

--- a/src/pyfia/estimation/data_loading.py
+++ b/src/pyfia/estimation/data_loading.py
@@ -650,8 +650,12 @@ class DataLoader:
         )
 
         # Select MACRO_BREAKPOINT_DIA from PLOT table
-        # This is CRITICAL for correct adjustment factor selection in states with macroplots
-        plot_cols = [pl.col("CN").alias("PLT_CN"), "MACRO_BREAKPOINT_DIA"]
+        # This is CRITICAL for correct adjustment factor selection in states with macroplots.
+        # Cast to numeric in case the source DuckDB stored it as VARCHAR (#106).
+        plot_cols = [
+            pl.col("CN").alias("PLT_CN"),
+            pl.col("MACRO_BREAKPOINT_DIA").cast(pl.Float64),
+        ]
 
         # Include polygon attributes if they exist (from intersect_polygons)
         # This allows grp_by to use polygon attribute columns
@@ -668,7 +672,7 @@ class DataLoader:
             plot_schema = plot.collect_schema().names()
             for col in polygon_attr_cols:
                 if col in plot_schema:
-                    plot_cols.append(col)
+                    plot_cols.append(pl.col(col))
 
         plot_selected = plot.select(plot_cols)
 

--- a/src/pyfia/estimation/data_loading.py
+++ b/src/pyfia/estimation/data_loading.py
@@ -200,28 +200,28 @@ class DataLoader:
         tree_cols = list(tree_columns) if tree_columns else None
         cond_cols = list(cond_columns) if cond_columns else None
 
-        # Get table schemas to determine where grp_by columns live
+        # Get table schemas to determine where each referenced column lives
         tree_schema = list(self.db._reader.get_table_schema("TREE").keys())
         cond_schema = list(self.db._reader.get_table_schema("COND").keys())
 
-        # Add grouping columns from config if specified
-        # Note: Validation is done in __init__ via _validate_grp_by_columns()
-        grp_by = self.config.get("grp_by")
-        if grp_by:
-            if isinstance(grp_by, str):
-                grp_by = [grp_by]
+        # Route every user-referenced column (grp_by plus any column named in
+        # area_domain / tree_domain) into the table that actually holds it, so
+        # grouping and domain filtering resolve consistently (#103, #104).
+        # grp_by validity is checked in __init__ via _validate_grp_by_columns().
+        from .columns import collect_referenced_columns
 
-            for col in grp_by:
-                in_tree = col in tree_schema and (
-                    tree_cols is None or col not in tree_cols
-                )
-                in_cond = col in cond_schema and (
-                    cond_cols is None or col not in cond_cols
-                )
-                if tree_cols is not None and in_tree:
-                    tree_cols.append(col)
-                elif cond_cols is not None and in_cond:
-                    cond_cols.append(col)
+        referenced = collect_referenced_columns(
+            self.config.get("grp_by"),
+            self.config.get("area_domain"),
+            self.config.get("tree_domain"),
+        )
+        for col in referenced:
+            in_tree = col in tree_schema and (tree_cols is None or col not in tree_cols)
+            in_cond = col in cond_schema and (cond_cols is None or col not in cond_cols)
+            if tree_cols is not None and in_tree:
+                tree_cols.append(col)
+            elif cond_cols is not None and in_cond:
+                cond_cols.append(col)
 
         return tree_cols, cond_cols
 

--- a/src/pyfia/estimation/estimators/growth.py
+++ b/src/pyfia/estimation/estimators/growth.py
@@ -36,29 +36,10 @@ class GrowthEstimator(GRMBaseEstimator):
         """Return 'growth' as the GRM component type."""
         return "growth"
 
-    def get_cond_columns(self) -> list[str]:
-        """Required condition columns for growth estimation."""
-        base_cols = [
-            "PLT_CN",
-            "CONDID",
-            "COND_STATUS_CD",
-            "CONDPROP_UNADJ",
-            "OWNGRPCD",
-            "FORTYPCD",
-            "SITECLCD",
-            "RESERVCD",
-            "ALSTKCD",
-        ]
-
-        if self.config.get("grp_by"):
-            grp_cols = self.config["grp_by"]
-            if isinstance(grp_cols, str):
-                grp_cols = [grp_cols]
-            for col in grp_cols:
-                if col not in base_cols:
-                    base_cols.append(col)
-
-        return base_cols
+    # get_cond_columns is inherited from GRMBaseEstimator: it loads the base
+    # condition set plus any grp_by / area_domain / tree_domain column that
+    # exists in the COND table (schema-driven), so growth resolves condition
+    # columns identically to mortality/removals (#103, #104).
 
     def load_data(self) -> pl.LazyFrame | None:
         """

--- a/src/pyfia/estimation/estimators/growth.py
+++ b/src/pyfia/estimation/estimators/growth.py
@@ -90,6 +90,9 @@ class GrowthEstimator(GRMBaseEstimator):
 
         data = tree.select(tree_cols)
         if tree_vol_col:
+            # Cast to numeric in case the source DuckDB stored it as VARCHAR
+            # (#106); growth divides this value by REMPER.
+            data = data.with_columns(pl.col(tree_vol_col).cast(pl.Float64))
             data = data.rename({tree_vol_col: f"TREE_{tree_vol_col}"})
 
         # Load and join GRM_COMPONENT
@@ -134,8 +137,10 @@ class GrowthEstimator(GRMBaseEstimator):
 
         # Join PTREE for fallback
         if measure in ("volume", "biomass") and tree_vol_col is not None:
-            ptree = tree.select(["CN", tree_vol_col]).rename(
-                {tree_vol_col: f"PTREE_{tree_vol_col}"}
+            ptree = (
+                tree.select(["CN", tree_vol_col])
+                .with_columns(pl.col(tree_vol_col).cast(pl.Float64))
+                .rename({tree_vol_col: f"PTREE_{tree_vol_col}"})
             )
             data = data.join(ptree, left_on="PREV_TRE_CN", right_on="CN", how="left")
 
@@ -174,6 +179,15 @@ class GrowthEstimator(GRMBaseEstimator):
                     plot_cols.append(col)
 
         plot = plot.select(plot_cols)
+
+        # Cast plot numerics in case the source DuckDB stored them as VARCHAR
+        # (#106); growth divides volumes by REMPER and uses MACRO_BREAKPOINT_DIA.
+        plot = plot.with_columns(
+            [
+                pl.col("REMPER").cast(pl.Float64),
+                pl.col("MACRO_BREAKPOINT_DIA").cast(pl.Float64),
+            ]
+        )
 
         data = data.join(plot, left_on="PLT_CN", right_on="CN", how="inner")
 

--- a/src/pyfia/estimation/grm.py
+++ b/src/pyfia/estimation/grm.py
@@ -184,19 +184,23 @@ def load_grm_component(
     if not isinstance(grm_component, pl.LazyFrame):
         grm_component = grm_component.lazy()
 
-    # Build column selection
+    # Build column selection. Numeric columns are cast to their declared types:
+    # some state DuckDBs (built from CSV/older snapshots) store FIADB numeric
+    # fields as VARCHAR, which breaks downstream division/comparison (#106).
+    # Strict casts fail loudly naming the offending column rather than silently
+    # nulling values, preserving statistical integrity.
     cols = [
         pl.col("TRE_CN"),
         pl.col("PLT_CN"),
-        pl.col("DIA_BEGIN"),
-        pl.col("DIA_MIDPT"),
+        pl.col("DIA_BEGIN").cast(pl.Float64),
+        pl.col("DIA_MIDPT").cast(pl.Float64),
         pl.col(grm_columns.component).alias("COMPONENT"),
-        pl.col(grm_columns.tpa).alias("TPA_UNADJ"),
-        pl.col(grm_columns.subptyp).alias("SUBPTYP_GRM"),
+        pl.col(grm_columns.tpa).cast(pl.Float64).alias("TPA_UNADJ"),
+        pl.col(grm_columns.subptyp).cast(pl.Int64).alias("SUBPTYP_GRM"),
     ]
 
     if include_dia_end:
-        cols.insert(4, pl.col("DIA_END"))
+        cols.insert(4, pl.col("DIA_END").cast(pl.Float64))
 
     result: pl.LazyFrame = grm_component.select(cols)
     return result
@@ -250,6 +254,23 @@ def load_grm_midpt(
         cols.extend([c for c in include_additional_cols if c not in cols])
 
     result: pl.LazyFrame = grm_midpt.select(cols)
+
+    # Cast numeric columns to their declared types in case the source DuckDB
+    # stored them as VARCHAR (see #106). Strict casts surface bad data loudly.
+    float_cols = {
+        "DIA",
+        "VOLCFNET",
+        "VOLCSNET",
+        "DRYBIO_BOLE",
+        "DRYBIO_BRANCH",
+        "DRYBIO_AG",
+    }
+    int_cols = {"SPCD", "STATUSCD"}
+    casts = [pl.col(c).cast(pl.Float64) for c in cols if c in float_cols]
+    casts += [pl.col(c).cast(pl.Int64) for c in cols if c in int_cols]
+    if casts:
+        result = result.with_columns(casts)
+
     return result
 
 
@@ -284,13 +305,22 @@ def load_grm_begin(
         grm_begin = grm_begin.lazy()
 
     cols = ["TRE_CN"]
+    value_col = None
 
     if measure == "volume":
-        cols.append("VOLCFNET")
+        value_col = "VOLCFNET"
     elif measure == "biomass":
-        cols.append("DRYBIO_AG")
+        value_col = "DRYBIO_AG"
+    if value_col:
+        cols.append(value_col)
 
     result: pl.LazyFrame = grm_begin.select(cols)
+
+    # Cast the value column to numeric in case the source stored it as VARCHAR
+    # (see #106).
+    if value_col:
+        result = result.with_columns(pl.col(value_col).cast(pl.Float64))
+
     return result
 
 

--- a/src/pyfia/estimation/grm.py
+++ b/src/pyfia/estimation/grm.py
@@ -354,32 +354,32 @@ def aggregate_cond_to_plot(cond: pl.LazyFrame) -> pl.LazyFrame:
         - PLT_CN
         - COND_STATUS_CD (from first/dominant condition)
         - CONDPROP_UNADJ (sum of all condition proportions)
-        - OWNGRPCD, FORTYPCD, SITECLCD, RESERVCD (from first condition, if present)
         - CONDID (dummy value of 1)
+        - every other loaded condition column (from the first condition)
+
+    Notes
+    -----
+    All loaded condition columns other than the explicitly handled keys are
+    carried to plot level via ``first()``. This preserves any grouping or
+    domain column threaded through the COND load (e.g. TRTCD1, DSTRBCD1)
+    instead of dropping anything outside a fixed allowlist, which is what
+    caused mortality()/removals() to lose group columns (#104).
     """
     # Get available columns
     available_cols = cond.collect_schema().names()
 
-    # Build aggregation list dynamically
+    # Columns aggregated with bespoke logic; all others are carried via first().
+    handled = {"PLT_CN", "COND_STATUS_CD", "CONDPROP_UNADJ", "CONDID"}
+
     agg_exprs = [
         pl.col("COND_STATUS_CD").first().alias("COND_STATUS_CD"),
         pl.col("CONDPROP_UNADJ").sum().alias("CONDPROP_UNADJ"),
         pl.lit(1).alias("CONDID"),
     ]
 
-    # Add optional columns if available
-    optional_cols = [
-        "OWNGRPCD",
-        "FORTYPCD",
-        "SITECLCD",
-        "RESERVCD",
-        "ALSTKCD",
-        "DSTRBCD1",  # Primary disturbance code
-        "DSTRBCD2",  # Secondary disturbance code
-        "DSTRBCD3",  # Tertiary disturbance code
-    ]
-    for col in optional_cols:
-        if col in available_cols:
+    # Carry every other loaded condition column to plot level (first condition).
+    for col in available_cols:
+        if col not in handled:
             agg_exprs.append(pl.col(col).first().alias(col))
 
     return cond.group_by("PLT_CN").agg(agg_exprs)

--- a/src/pyfia/estimation/grm_base.py
+++ b/src/pyfia/estimation/grm_base.py
@@ -542,7 +542,13 @@ class GRMBaseEstimator(BaseEstimator):
                     )
 
             if variance_results:
+                from .variance import align_join_key_dtypes
+
                 var_df = pl.DataFrame(variance_results)
+                # Align all-null group keys so a Null-typed key (e.g. a
+                # disturbance code null across every group) does not break the
+                # join against the typed results key (#105).
+                var_df = align_join_key_dtypes(results, var_df, group_cols)
                 results = results.join(var_df, on=group_cols, how="left")
         else:
             # No grouping, calculate overall variance with ALL plots

--- a/src/pyfia/estimation/grm_base.py
+++ b/src/pyfia/estimation/grm_base.py
@@ -63,8 +63,9 @@ class GRMBaseEstimator(BaseEstimator):
                 suggestion=(
                     "GRM estimates require an EVALID filter to avoid counting trees "
                     "multiple times across evaluations. Call "
-                    "db.clip_by_evalid(evalid) or db.clip_most_recent(eval_type='GRM') "
-                    "before calling estimation functions."
+                    "db.clip_by_evalid(evalid), or db.clip_most_recent(eval_type='GRM') "
+                    "for the whole growth/removal/mortality family, before calling "
+                    "estimation functions."
                 ),
             )
 
@@ -446,7 +447,11 @@ class GRMBaseEstimator(BaseEstimator):
             plot_level_cols.insert(1, "STRATUM_CN")
         if group_cols:
             plot_level_cols.extend(
-                [c for c in group_cols if c in plot_cond_data.columns and c not in plot_level_cols]
+                [
+                    c
+                    for c in group_cols
+                    if c in plot_cond_data.columns and c not in plot_level_cols
+                ]
             )
 
         # Include CONDPROP_UNADJ for area calculation

--- a/src/pyfia/estimation/grm_base.py
+++ b/src/pyfia/estimation/grm_base.py
@@ -15,7 +15,7 @@ import polars as pl
 from ..core.exceptions import NoEVALIDError
 from ..filtering.utils import create_size_class_expr
 from .base import AggregationResult, BaseEstimator
-from .columns import get_cond_columns as _get_cond_columns
+from .columns import collect_referenced_columns, columns_in_table
 
 logger = logging.getLogger(__name__)
 
@@ -97,21 +97,35 @@ class GRMBaseEstimator(BaseEstimator):
         return get_grm_required_tables(self.component_type)
 
     def get_cond_columns(self) -> list[str]:
-        """Standard condition columns for GRM estimation.
+        """Condition columns for GRM estimation.
 
-        Uses centralized column resolution from columns.py to reduce duplication.
-        GRM estimation needs additional columns for filtering and grouping.
+        Loads the base condition set plus the GRM helper columns used by
+        aggregate_cond_to_plot() and land-basis filtering, then adds any
+        grp_by / area_domain / tree_domain column that actually lives in the
+        COND table. Resolving against the real COND schema (rather than a fixed
+        allowlist) lets grouping and domain filtering use the same set of
+        condition columns, fixing #103 and #104.
         """
-        base_cols = _get_cond_columns(
-            land_type=self.config.get("land_type", "forest"),
-            grp_by=self.config.get("grp_by"),
-            include_prop_basis=False,
-        )
+        base_cols = [
+            "PLT_CN",
+            "CONDID",
+            "COND_STATUS_CD",
+            "CONDPROP_UNADJ",
+            "OWNGRPCD",
+            "FORTYPCD",
+            "SITECLCD",
+            "RESERVCD",
+            "ALSTKCD",
+        ]
 
-        # GRM estimation needs these columns for aggregate_cond_to_plot()
-        # and filtering by forest type, ownership, etc.
-        grm_cols = ["OWNGRPCD", "FORTYPCD", "SITECLCD", "RESERVCD", "ALSTKCD"]
-        for col in grm_cols:
+        # Add any user-referenced column that exists in the COND table so that
+        # grp_by and area_domain/tree_domain resolve identically.
+        referenced = collect_referenced_columns(
+            self.config.get("grp_by"),
+            self.config.get("area_domain"),
+            self.config.get("tree_domain"),
+        )
+        for col in columns_in_table(self.db, "COND", referenced):
             if col not in base_cols:
                 base_cols.append(col)
 

--- a/src/pyfia/estimation/variance.py
+++ b/src/pyfia/estimation/variance.py
@@ -78,6 +78,47 @@ import polars as pl
 from .constants import Z_SCORE_90, Z_SCORE_95, Z_SCORE_99
 
 
+def align_join_key_dtypes(
+    left: pl.DataFrame, right: pl.DataFrame, keys: list[str]
+) -> pl.DataFrame:
+    """Cast ``right``'s join keys to ``left``'s dtypes where ``right`` is Null-typed.
+
+    Variance results are assembled per group (often from Python dicts), so when
+    a grouping key is null for every group -- e.g. a disturbance or treatment
+    code that is entirely null in a given state's filtered conditions -- polars
+    infers that key as ``Null`` dtype. Joining it against the concrete (e.g.
+    ``Int64``) key on the results frame then raises a ``SchemaError``. Casting
+    the Null-typed key to the results dtype before the join avoids the error
+    without changing any joined value, since an all-null column carries no data
+    (issue #105).
+
+    Parameters
+    ----------
+    left : pl.DataFrame
+        Frame whose key dtypes are authoritative (the results frame).
+    right : pl.DataFrame
+        Frame whose Null-typed keys should be aligned (the variance frame).
+    keys : list[str]
+        Join key column names.
+
+    Returns
+    -------
+    pl.DataFrame
+        ``right`` with any Null-typed join key cast to ``left``'s dtype.
+    """
+    casts = [
+        pl.col(k).cast(left.schema[k])
+        for k in keys
+        if k in left.columns
+        and k in right.columns
+        and right.schema[k] == pl.Null
+        and left.schema[k] != pl.Null
+    ]
+    if casts:
+        right = right.with_columns(casts)
+    return right
+
+
 def calculate_grouped_domain_total_variance(
     plot_data: pl.DataFrame,
     group_cols: list[str],

--- a/tests/integration/test_grm_cond_columns.py
+++ b/tests/integration/test_grm_cond_columns.py
@@ -1,0 +1,99 @@
+"""Integration tests for the GRM/COND column cluster (#102, #103, #104).
+
+These exercise the real estimators against the Georgia FIA database, which has
+the GRM tables, the EXPGROW/EXPMORT/EXPREMV family, and the COND columns
+DSTRBCD1/TRTCD1/FORTYPCD. They skip automatically when no local database is
+available (e.g. in CI); the CI-safe guards for this cluster live in
+tests/unit/test_eval_type_resolution.py, test_variance_join_dtypes.py, and
+test_grm_numeric_cast.py.
+"""
+
+import pytest
+
+from pyfia import FIA, biomass, growth, mortality, removals
+
+pytestmark = [pytest.mark.integration, pytest.mark.db]
+
+GA_FIPS = 13
+
+# (function, eval_type token, estimator-specific kwargs)
+GRM_SPECS = [
+    (growth, "GROW", dict(measure="biomass", tree_type="all")),
+    (mortality, "MORT", dict(measure="biomass", tree_type="all")),
+    (removals, "REMV", dict(measure="biomass", tree_type="all")),
+    (biomass, "VOL", dict(component="AG", tree_type="live")),
+]
+
+
+@pytest.fixture
+def ga_path(georgia_db_path):
+    """String path/connection for building fresh FIA instances per estimator."""
+    return georgia_db_path if isinstance(georgia_db_path, str) else str(georgia_db_path)
+
+
+def _clip(path, token):
+    db = FIA(path)
+    db.clip_by_state(GA_FIPS)
+    db.clip_most_recent(eval_type=token)
+    return db
+
+
+class TestGRMAlias:
+    """#102: clip_most_recent(eval_type='GRM') resolves the shared family EVALID."""
+
+    def test_grm_alias_sets_evalid(self, ga_path):
+        db = FIA(ga_path)
+        db.clip_by_state(GA_FIPS)
+        # Must not raise NoEVALIDError, and must select a single shared EVALID.
+        db.clip_most_recent(eval_type="GRM")
+        assert db.evalid is not None
+        assert len(db.evalid) == 1
+
+    def test_grm_alias_matches_component_tokens(self, ga_path):
+        db = FIA(ga_path)
+        db.clip_by_state(GA_FIPS)
+        grm = db.find_evalid(most_recent=True, eval_type="GRM", state=[GA_FIPS])
+        grow = db.find_evalid(most_recent=True, eval_type="GROW", state=[GA_FIPS])
+        mort = db.find_evalid(most_recent=True, eval_type="MORT", state=[GA_FIPS])
+        remv = db.find_evalid(most_recent=True, eval_type="REMV", state=[GA_FIPS])
+        # The family share one EVALID, so GRM equals each component's EVALID.
+        assert grm == grow == mort == remv
+        assert len(grm) == 1
+
+
+class TestAreaDomainOnCondColumn:
+    """#103: area_domain can filter on a COND column that grp_by accepts."""
+
+    @pytest.mark.parametrize(
+        "fn,token,kwargs", GRM_SPECS, ids=[s[0].__name__ for s in GRM_SPECS]
+    )
+    def test_area_domain_dstrbcd1(self, ga_path, fn, token, kwargs):
+        db = _clip(ga_path, token)
+        # Previously raised ColumnNotFoundError for the GRM estimators.
+        result = fn(db, land_type="forest", area_domain="DSTRBCD1 > 0", **kwargs)
+        assert result is not None
+
+    @pytest.mark.parametrize(
+        "fn,token,kwargs", GRM_SPECS, ids=[s[0].__name__ for s in GRM_SPECS]
+    )
+    def test_area_domain_trtcd1(self, ga_path, fn, token, kwargs):
+        db = _clip(ga_path, token)
+        result = fn(db, land_type="forest", area_domain="TRTCD1 == 10", **kwargs)
+        assert result is not None
+
+
+class TestGrpByExtraCondColumn:
+    """#104: a 3-column grp_by including TRTCD1 works for all four estimators."""
+
+    GRP = ["FORTYPCD", "DSTRBCD1", "TRTCD1"]
+
+    @pytest.mark.parametrize(
+        "fn,token,kwargs", GRM_SPECS, ids=[s[0].__name__ for s in GRM_SPECS]
+    )
+    def test_grp_by_retains_trtcd1(self, ga_path, fn, token, kwargs):
+        db = _clip(ga_path, token)
+        result = fn(db, land_type="forest", grp_by=self.GRP, totals=True, **kwargs)
+        # The extra COND column must survive into the grouped output.
+        assert "TRTCD1" in result.columns
+        assert "DSTRBCD1" in result.columns
+        assert "FORTYPCD" in result.columns

--- a/tests/unit/test_eval_type_resolution.py
+++ b/tests/unit/test_eval_type_resolution.py
@@ -1,0 +1,124 @@
+"""Unit tests for eval_type token resolution and the "GRM" alias (issue #102).
+
+clip_most_recent(eval_type="GRM") previously built a non-existent "EXPGRM"
+EVAL_TYP and always raised NoEVALIDError. These tests pin the token->EVAL_TYP
+mapping, the "GRM" family alias, raw-code passthrough, and the helpful error
+for unknown tokens. All are CI-safe (no database required).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import polars as pl
+import pytest
+
+from pyfia.core.fia import resolve_eval_typ_codes
+
+
+class TestResolveEvalTypCodes:
+    """Pure-function token resolution."""
+
+    def test_grm_expands_to_family(self):
+        assert resolve_eval_typ_codes("GRM") == ["EXPGROW", "EXPMORT", "EXPREMV"]
+
+    def test_single_tokens(self):
+        assert resolve_eval_typ_codes("VOL") == ["EXPVOL"]
+        assert resolve_eval_typ_codes("GROW") == ["EXPGROW"]
+        assert resolve_eval_typ_codes("MORT") == ["EXPMORT"]
+        assert resolve_eval_typ_codes("REMV") == ["EXPREMV"]
+        assert resolve_eval_typ_codes("ALL") == ["EXPALL"]
+
+    def test_case_insensitive(self):
+        assert resolve_eval_typ_codes("grm") == ["EXPGROW", "EXPMORT", "EXPREMV"]
+        assert resolve_eval_typ_codes("  Vol ") == ["EXPVOL"]
+
+    def test_raw_code_passthrough(self):
+        # Callers may pass a raw EVAL_TYP code directly.
+        assert resolve_eval_typ_codes("EXPALL") == ["EXPALL"]
+        assert resolve_eval_typ_codes("EXPVOL") == ["EXPVOL"]
+
+    def test_unknown_token_raises_with_options(self):
+        with pytest.raises(ValueError) as exc:
+            resolve_eval_typ_codes("EXPGRM")
+        msg = str(exc.value)
+        assert "EXPGRM" in msg
+        # The message must list valid options including the GRM alias.
+        assert "GRM" in msg
+        assert "GROW" in msg
+
+    def test_other_unknown_token_raises(self):
+        with pytest.raises(ValueError):
+            resolve_eval_typ_codes("NONSENSE")
+
+
+@pytest.fixture
+def mock_fia():
+    """Mock FIA instance exposing the real find_evalid method."""
+    from pyfia.core.fia import FIA
+
+    with patch.object(FIA, "__init__", lambda self: None):
+        db = FIA()
+        db.tables = {}
+        db.evalid = None
+        db.state_filter = None
+        db._reader = MagicMock()
+        return db
+
+
+class TestGRMAliasResolution:
+    """find_evalid(eval_type="GRM") resolves to the shared family EVALID."""
+
+    def test_grm_resolves_to_shared_family_evalid(self, mock_fia):
+        # EXPGROW/EXPMORT/EXPREMV share one EVALID per state; a separate VOL
+        # evaluation must not be selected by the GRM alias.
+        mock_fia.tables["POP_EVAL"] = pl.DataFrame(
+            {
+                "CN": ["grow", "mort", "remv", "vol"],
+                "EVALID": [132403, 132403, 132403, 132401],
+                "STATECD": [13, 13, 13, 13],
+                "END_INVYR": [2024, 2024, 2024, 2024],
+                "LOCATION_NM": ["Georgia"] * 4,
+            }
+        ).lazy()
+        mock_fia.tables["POP_EVAL_TYP"] = pl.DataFrame(
+            {
+                "CN": ["t1", "t2", "t3", "t4"],
+                "EVAL_CN": ["grow", "mort", "remv", "vol"],
+                "EVAL_TYP": ["EXPGROW", "EXPMORT", "EXPREMV", "EXPVOL"],
+            }
+        ).lazy()
+
+        result = mock_fia.find_evalid(most_recent=True, eval_type="GRM", state=[13])
+
+        assert result == [132403], (
+            f"GRM alias should resolve to the shared family EVALID 132403, got {result}"
+        )
+
+    def test_grm_picks_most_recent_family_evalid(self, mock_fia):
+        # Two annual GRM evaluations; the most recent shared EVALID wins.
+        mock_fia.tables["POP_EVAL"] = pl.DataFrame(
+            {
+                "CN": ["g23", "m23", "r23", "g24", "m24", "r24"],
+                "EVALID": [132303, 132303, 132303, 132403, 132403, 132403],
+                "STATECD": [13, 13, 13, 13, 13, 13],
+                "END_INVYR": [2023, 2023, 2023, 2024, 2024, 2024],
+                "LOCATION_NM": ["Georgia"] * 6,
+            }
+        ).lazy()
+        mock_fia.tables["POP_EVAL_TYP"] = pl.DataFrame(
+            {
+                "CN": ["a", "b", "c", "d", "e", "f"],
+                "EVAL_CN": ["g23", "m23", "r23", "g24", "m24", "r24"],
+                "EVAL_TYP": [
+                    "EXPGROW",
+                    "EXPMORT",
+                    "EXPREMV",
+                    "EXPGROW",
+                    "EXPMORT",
+                    "EXPREMV",
+                ],
+            }
+        ).lazy()
+
+        result = mock_fia.find_evalid(most_recent=True, eval_type="GRM", state=[13])
+
+        assert result == [132403]

--- a/tests/unit/test_grm_numeric_cast.py
+++ b/tests/unit/test_grm_numeric_cast.py
@@ -1,0 +1,105 @@
+"""Unit tests for GRM numeric-column casting at load (issue #106).
+
+Some state DuckDBs store FIADB numeric fields (SUBP_TPA*_UNADJ_*, REMPER,
+DIA*, DRYBIO_*, ...) as VARCHAR, which broke GRM arithmetic (division on
+String, comparing String to numeric). The load_grm_* helpers cast these to
+their declared numeric types. These tests feed VARCHAR-typed frames through a
+lightweight mock db and assert the loaded dtypes, with no database required.
+"""
+
+from types import SimpleNamespace
+
+import polars as pl
+
+from pyfia.estimation.grm import (
+    load_grm_begin,
+    load_grm_component,
+    load_grm_midpt,
+    resolve_grm_columns,
+)
+
+
+def _mock_db(table_name, frame):
+    """A minimal db whose .tables holds a single lazy frame."""
+    return SimpleNamespace(tables={table_name: frame.lazy()})
+
+
+class TestLoadGRMComponentCast:
+    def test_varchar_columns_cast_to_numeric(self):
+        cols = resolve_grm_columns("removals", tree_type="gs", land_type="forest")
+        frame = pl.DataFrame(
+            {
+                "TRE_CN": ["1"],
+                "PLT_CN": ["10"],
+                "DIA_BEGIN": ["5.0"],
+                "DIA_MIDPT": ["6.5"],
+                "DIA_END": ["7.0"],
+                cols.component: ["CUT1"],
+                cols.tpa: ["0.595846"],  # VARCHAR TPA, as seen in WY
+                cols.subptyp: ["1"],
+            }
+        )
+        db = _mock_db("TREE_GRM_COMPONENT", frame)
+
+        out = load_grm_component(db, cols, include_dia_end=True).collect()
+
+        assert out.schema["TPA_UNADJ"] == pl.Float64
+        assert out.schema["SUBPTYP_GRM"] == pl.Int64
+        assert out.schema["DIA_MIDPT"] == pl.Float64
+        assert out.schema["DIA_BEGIN"] == pl.Float64
+        assert out.schema["DIA_END"] == pl.Float64
+        # Value preserved through the cast.
+        assert abs(out["TPA_UNADJ"][0] - 0.595846) < 1e-9
+        assert out["SUBPTYP_GRM"][0] == 1
+
+    def test_already_numeric_unchanged(self):
+        cols = resolve_grm_columns("growth", tree_type="gs", land_type="forest")
+        frame = pl.DataFrame(
+            {
+                "TRE_CN": ["1"],
+                "PLT_CN": ["10"],
+                "DIA_BEGIN": [5.0],
+                "DIA_MIDPT": [6.5],
+                cols.component: ["SURVIVOR"],
+                cols.tpa: [0.5],
+                cols.subptyp: [1],
+            }
+        )
+        db = _mock_db("TREE_GRM_COMPONENT", frame)
+        out = load_grm_component(db, cols, include_dia_end=False).collect()
+        assert out.schema["TPA_UNADJ"] == pl.Float64
+        assert out["TPA_UNADJ"][0] == 0.5
+
+
+class TestLoadGRMMidptCast:
+    def test_varchar_measure_columns_cast(self):
+        frame = pl.DataFrame(
+            {
+                "TRE_CN": ["1"],
+                "DIA": ["6.5"],
+                "SPCD": ["131"],
+                "STATUSCD": ["1"],
+                "DRYBIO_BOLE": ["100.0"],
+                "DRYBIO_BRANCH": ["25.0"],
+                "DRYBIO_AG": ["140.0"],
+            }
+        )
+        db = _mock_db("TREE_GRM_MIDPT", frame)
+
+        out = load_grm_midpt(db, measure="biomass").collect()
+
+        assert out.schema["DIA"] == pl.Float64
+        assert out.schema["DRYBIO_BOLE"] == pl.Float64
+        assert out.schema["DRYBIO_BRANCH"] == pl.Float64
+        assert out.schema["DRYBIO_AG"] == pl.Float64
+        assert out.schema["SPCD"] == pl.Int64
+        assert out.schema["STATUSCD"] == pl.Int64
+
+
+class TestLoadGRMBeginCast:
+    def test_varchar_value_column_cast(self):
+        frame = pl.DataFrame({"TRE_CN": ["1"], "DRYBIO_AG": ["120.0"]})
+        db = _mock_db("TREE_GRM_BEGIN", frame)
+        out = load_grm_begin(db, measure="biomass").collect()
+        assert out.schema["DRYBIO_AG"] == pl.Float64
+        assert out["DRYBIO_AG"][0] == 120.0

--- a/tests/unit/test_variance_join_dtypes.py
+++ b/tests/unit/test_variance_join_dtypes.py
@@ -1,0 +1,73 @@
+"""Unit tests for variance-join dtype alignment (issue #105).
+
+biomass(grp_by=DSTRBCD1) crashed on states where the grouping column is null
+across every group: per-group variance rows assembled into a DataFrame infer a
+polars Null dtype, which cannot join against the Int64 key on the results
+frame. align_join_key_dtypes() casts the Null-typed key up to the results dtype
+before the join. These tests are synthetic and CI-safe (no database).
+"""
+
+import polars as pl
+
+from pyfia.estimation.variance import align_join_key_dtypes
+
+
+class TestAlignJoinKeyDtypes:
+    def test_casts_null_key_to_left_dtype(self):
+        left = pl.DataFrame(
+            {"FORTYPCD": [161], "DSTRBCD1": [None], "EST": [1.0]},
+            schema={"FORTYPCD": pl.Int64, "DSTRBCD1": pl.Int64, "EST": pl.Float64},
+        )
+        # var_df built from all-None group values -> Null dtype key.
+        right = pl.DataFrame({"FORTYPCD": [161], "DSTRBCD1": [None], "SE": [0.5]})
+        assert right.schema["DSTRBCD1"] == pl.Null
+
+        aligned = align_join_key_dtypes(left, right, ["FORTYPCD", "DSTRBCD1"])
+        assert aligned.schema["DSTRBCD1"] == pl.Int64
+
+    def test_join_succeeds_after_alignment(self):
+        # Reproduces the #105 shape: an all-null Int64 key on the left and a
+        # Null-dtype key on the right. The raw join raises SchemaError.
+        left = pl.DataFrame(
+            {"FORTYPCD": [161, 162], "DSTRBCD1": [None, None], "EST": [1.0, 2.0]},
+            schema={"FORTYPCD": pl.Int64, "DSTRBCD1": pl.Int64, "EST": pl.Float64},
+        )
+        right = pl.DataFrame(
+            {"FORTYPCD": [161, 162], "DSTRBCD1": [None, None], "SE": [0.1, 0.2]}
+        )
+
+        # Without alignment polars refuses the join.
+        try:
+            left.join(right, on=["FORTYPCD", "DSTRBCD1"], how="left")
+            raised = False
+        except pl.exceptions.SchemaError:
+            raised = True
+        assert raised, "expected a SchemaError without dtype alignment"
+
+        # With alignment the join works (no exception).
+        right2 = align_join_key_dtypes(left, right, ["FORTYPCD", "DSTRBCD1"])
+        joined = left.join(right2, on=["FORTYPCD", "DSTRBCD1"], how="left")
+        assert joined.shape[0] == 2
+
+    def test_does_not_change_matching_dtypes(self):
+        # When the right key is already typed, the frame is returned unchanged.
+        left = pl.DataFrame(
+            {"DSTRBCD1": [0, 1], "EST": [1.0, 2.0]},
+            schema={"DSTRBCD1": pl.Int64, "EST": pl.Float64},
+        )
+        right = pl.DataFrame(
+            {"DSTRBCD1": [0, 1], "SE": [0.1, 0.2]},
+            schema={"DSTRBCD1": pl.Int64, "SE": pl.Float64},
+        )
+        aligned = align_join_key_dtypes(left, right, ["DSTRBCD1"])
+        assert aligned.schema["DSTRBCD1"] == pl.Int64
+        # Non-null keyed groups still join to their values unchanged.
+        joined = left.join(aligned, on=["DSTRBCD1"], how="left")
+        assert joined["SE"].to_list() == [0.1, 0.2]
+
+    def test_ignores_keys_absent_from_a_frame(self):
+        left = pl.DataFrame({"A": [1]}, schema={"A": pl.Int64})
+        right = pl.DataFrame({"A": [None]})
+        # "MISSING" is not in either frame; must be skipped without error.
+        aligned = align_join_key_dtypes(left, right, ["A", "MISSING"])
+        assert aligned.schema["A"] == pl.Int64


### PR DESCRIPTION
## Summary

Fixes the GRM / COND-column cluster reported while building disturbance × treatment-stratified FIA carbon stock-change against per-state FIADB DuckDBs. All five issues reproduced against real state databases and are fixed here, with the previously-working, EVALIDator-validated numbers held as the guardrail.

Closes #102. Closes #103. Closes #104. Closes #105. Closes #106.

## Fixes

- **#102 — `eval_type="GRM"` always raised `NoEVALIDError`.** `find_evalid` built a non-existent `EXPGRM` code. Replaced the `EXP{token}` string with an explicit token→`EVAL_TYP` map: `"GRM"` resolves to the shared `EXPGROW/EXPMORT/EXPREMV` family EVALID, raw `EXP*` codes pass through, and unknown tokens raise a `ValueError` listing valid options. Docstrings and the GRM `NoEVALIDError` text updated.

- **#103 — `area_domain` could not reference COND columns that `grp_by` accepts.** Added a schema-driven resolver (`collect_referenced_columns` + `columns_in_table`) that gathers every `grp_by` / `area_domain` / `tree_domain` column and routes each into the table that actually holds it. All four estimators now resolve condition columns identically.

- **#104 — `mortality()` / `removals()` crashed on `grp_by` columns outside the old allowlist (e.g. `TRTCD1`).** `aggregate_cond_to_plot` now carries every loaded COND column to plot level via `first()` instead of a fixed list, so threaded grouping columns survive into the variance step. `growth` drops its bespoke `get_cond_columns` and inherits the shared resolver.

- **#105 — `biomass(grp_by=DSTRBCD1)` crashed on states where the key is null for every group (e.g. OR).** Per-group variance rows assembled into a DataFrame inferred a polars `Null` dtype that could not join against the `Int64` key on the results frame. Added `align_join_key_dtypes`, applied at the three variance→results join sites, to cast a `Null`-typed key up to the results dtype before joining. An all-null column carries no data, so no joined value changes.

- **#106 — GRM estimators crashed on state DBs storing numeric columns as `VARCHAR` (AZ, NM, WY growth; MT, NV removals).** Cast the GRM arithmetic columns (`SUBP_TPA*_UNADJ_*`, `REMPER`, `DIA*`, `DRYBIO_*`, `MACRO_BREAKPOINT_DIA`, …) to their declared numeric types at load (Float64 for continuous, Int64 for code fields). Strict casts surface any genuinely non-numeric value loudly, naming the column, rather than silently nulling it.

## No regression to validated numbers

The estimation math, variance formulas, and EVALIDator-validated outputs for currently-working paths are unchanged. Verified at each phase by stash-diffing estimates: no-`grp_by` **and** `grp_by=FORTYPCD`/`DSTRBCD1` results (and their SEs) for growth/mortality/removals/biomass on NC and OR are byte-identical before and after.

## Tests

- `tests/unit/test_eval_type_resolution.py` (#102): token mapping, GRM family alias, raw-code passthrough, helpful unknown-token error.
- `tests/unit/test_variance_join_dtypes.py` (#105): synthetic all-null `Null`-dtype join key aligns and joins without `SchemaError`; CI-safe.
- `tests/unit/test_grm_numeric_cast.py` (#106): VARCHAR numeric columns cast to declared types; CI-safe.
- `tests/integration/test_grm_cond_columns.py` (#102/#103/#104): DB-backed (Georgia) checks for the GRM alias, `area_domain` on COND columns across all four estimators, and a 3-column `grp_by` retaining `TRTCD1`. Skips automatically when no local database is available.

Full suite: 803 passed, 1 failed — the single failure (`test_intersect_polygons_with_area_grp_by`) is pre-existing on `main`, in the unrelated spatial+area path, and not touched by this change. `ruff check` and `mypy src/pyfia/` are clean.
