### PR TITLE
docs: fix v1.4.1 docs-audit accuracy bugs + regenerate API reference

### DIFF
--- a/docs/api/pyfia-core-fia.mdx
+++ b/docs/api/pyfia-core-fia.mdx
@@ -13,9 +13,32 @@ This module provides the main FIA class that handles database connections,
 EVALID-based filtering, and common FIA data operations.
 
 
+## Functions
+
+### `resolve_eval_typ_codes` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L60" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+
+```python
+resolve_eval_typ_codes(eval_type: str) -> list[str]
+```
+
+
+Resolve an ``eval_type`` token to its FIA ``EVAL_TYP`` code(s).
+
+Accepts both friendly tokens (``"VOL"``, ``"GRM"``, ``"GROW"`` ...) and raw
+``EVAL_TYP`` codes (``"EXPVOL"`` ...). ``"GRM"`` expands to the full
+growth/removal/mortality family.
+
+**Args:**
+- `eval_type`: Evaluation type token or raw ``EVAL_TYP`` code (case-insensitive).
+
+**Returns:**
+- One or more ``EVAL_TYP`` codes to match against ``POP_EVAL_TYP``.
+
+
+
 ## Classes
 
-### `FIA` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L33" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `FIA` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 Main FIA database class for working with Forest Inventory and Analysis data.
@@ -32,7 +55,7 @@ filtering by EVALID, and preparing data for estimation functions.
 
 **Methods:**
 
-#### `from_download` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L96" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `from_download` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L159" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 from_download(cls, states: str | list[str], dir: str | Path | None = None, common: bool = True, tables: list[str] | None = None, force: bool = False, show_progress: bool = True) -> FIA
@@ -67,7 +90,7 @@ Supports multiple states\: ['GA', 'FL', 'SC']
 >>> db = FIA.from_download(["GA", "FL", "SC"])
 
 
-#### `query` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L165" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `query` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L228" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 query(self, sql: str) -> pl.DataFrame
@@ -91,7 +114,7 @@ Only SELECT statements are allowed.
 ...     result = db.query("SELECT FORTYPCD, COUNT(*) as n FROM COND GROUP BY FORTYPCD")
 
 
-#### `load_table` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L282" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `load_table` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L345" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_table(self, table_name: str, columns: list[str] | None = None, where: str | None = None) -> pl.LazyFrame
@@ -109,7 +132,7 @@ Used for database-side filtering to reduce memory usage.
 - Polars LazyFrame of the requested table.
 
 
-#### `find_evalid` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L392" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `find_evalid` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L455" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 find_evalid(self, most_recent: bool = True, state: int | list[int] | None = None, year: int | list[int] | None = None, eval_type: str | None = None) -> list[int]
@@ -123,13 +146,16 @@ Identify evaluation IDs for filtering FIA data based on specific criteria.
 - `most_recent`: If True, return only most recent evaluations per state.
 - `state`: State FIPS code(s) to filter by.
 - `year`: End inventory year(s) to filter by.
-- `eval_type`: Evaluation type ('VOL', 'GRM', 'CHNG', 'ALL', etc.).
+- `eval_type`: Evaluation type token. One of 'ALL', 'VOL', 'GRM', 'GROW', 'MORT',
+'REMV', 'CHNG', 'DWM', 'REGEN', 'INV', 'CURR', or a raw EVAL_TYP
+code (e.g. 'EXPVOL'). 'GRM' is an alias for the growth/removal/
+mortality family. Unknown tokens raise ValueError.
 
 **Returns:**
 - EVALID values matching the specified criteria.
 
 
-#### `clip_by_evalid` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L536" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `clip_by_evalid` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L600" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 clip_by_evalid(self, evalid: int | list[int]) -> FIA
@@ -147,7 +173,7 @@ plot groupings by evaluation.
 - Self for method chaining.
 
 
-#### `clip_by_state` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L574" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `clip_by_state` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L638" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 clip_by_state(self, state: int | list[int], most_recent: bool = True, eval_type: str | None = 'ALL') -> FIA
@@ -170,7 +196,7 @@ appropriate for area estimation. Use None to get all types.
 - Self for method chaining.
 
 
-#### `clip_most_recent` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L635" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `clip_most_recent` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L699" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 clip_most_recent(self, eval_type: str = 'VOL') -> FIA
@@ -179,13 +205,16 @@ clip_most_recent(self, eval_type: str = 'VOL') -> FIA
 Filter to most recent evaluation of specified type.
 
 **Args:**
-- `eval_type`: Evaluation type ('VOL' for volume, 'GRM' for growth, etc.).
+- `eval_type`: Evaluation type token. 'VOL' for volume/biomass/TPA/area;
+'GRM' for growth, removals, and mortality together (or the
+component-specific 'GROW', 'MORT', 'REMV'); 'CHNG' for change.
+See find_evalid for the full list of accepted tokens.
 
 **Returns:**
 - Self for method chaining.
 
 
-#### `clip_by_polygon` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L670" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `clip_by_polygon` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L737" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 clip_by_polygon(self, polygon: str | Path, predicate: str = 'intersects') -> FIA
@@ -223,7 +252,7 @@ Supports Shapefiles, GeoJSON, GeoPackage, and GeoParquet formats.
 ...     result = db.area()
 
 
-#### `intersect_polygons` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L838" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `intersect_polygons` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L905" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 intersect_polygons(self, polygon: str | Path, attributes: list[str]) -> FIA
@@ -263,7 +292,7 @@ exist in the polygon file and will be available for grp_by.
 ...     result = area(db, grp_by=["REGION", "DISTRICT"])
 
 
-#### `get_plots` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1018" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `get_plots` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1085" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_plots(self, columns: list[str] | None = None) -> pl.DataFrame
@@ -278,7 +307,7 @@ Get PLOT table filtered by current EVALID, state, and spatial settings.
 - Filtered PLOT dataframe.
 
 
-#### `get_trees` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1074" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `get_trees` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1141" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_trees(self, columns: list[str] | None = None) -> pl.DataFrame
@@ -293,7 +322,7 @@ Get TREE table filtered by current EVALID and state settings.
 - Filtered TREE dataframe.
 
 
-#### `get_conditions` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1110" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `get_conditions` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1177" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_conditions(self, columns: list[str] | None = None) -> pl.DataFrame
@@ -308,7 +337,7 @@ Get COND table filtered by current EVALID and state settings.
 - Filtered COND dataframe.
 
 
-#### `prepare_estimation_data` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1146" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `prepare_estimation_data` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1213" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 prepare_estimation_data(self, include_trees: bool = True) -> dict[str, pl.DataFrame]
@@ -331,7 +360,7 @@ memory on constrained environments).
 If include_trees=False, 'tree' will be an empty DataFrame.
 
 
-#### `tpa` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1227" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `tpa` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1294" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 tpa(self, **kwargs) -> pl.DataFrame
@@ -342,7 +371,7 @@ Estimate trees per acre.
 See tpa() function for full parameter documentation.
 
 
-#### `biomass` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1238" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `biomass` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1305" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 biomass(self, **kwargs) -> pl.DataFrame
@@ -353,7 +382,7 @@ Estimate biomass.
 See biomass() function for full parameter documentation.
 
 
-#### `volume` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1249" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `volume` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1316" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 volume(self, **kwargs) -> pl.DataFrame
@@ -364,7 +393,7 @@ Estimate volume.
 See volume() function for full parameter documentation.
 
 
-#### `mortality` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1260" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `mortality` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1327" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 mortality(self, **kwargs) -> pl.DataFrame
@@ -375,7 +404,7 @@ Estimate mortality.
 See mortality() function for full parameter documentation.
 
 
-#### `area` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1270" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `area` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1337" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 area(self, **kwargs) -> pl.DataFrame
@@ -386,7 +415,7 @@ Estimate forest area.
 See area() function for full parameter documentation.
 
 
-#### `growth` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1280" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `growth` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1347" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 growth(self, **kwargs) -> pl.DataFrame
@@ -397,7 +426,7 @@ Estimate annual growth.
 See growth() function for full parameter documentation.
 
 
-#### `removals` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1290" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `removals` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1357" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 removals(self, **kwargs) -> pl.DataFrame
@@ -408,7 +437,7 @@ Estimate annual removals/harvest.
 See removals() function for full parameter documentation.
 
 
-#### `area_change` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1316" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `area_change` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1383" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 area_change(self, **kwargs) -> pl.DataFrame
@@ -419,7 +448,7 @@ Estimate area change.
 See area_change() function for full parameter documentation.
 
 
-### `MotherDuckFIA` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1327" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `MotherDuckFIA` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1394" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 
 FIA database class for MotherDuck cloud-based access.
@@ -447,7 +476,7 @@ warehouse built on DuckDB.
 
 **Methods:**
 
-#### `close` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1397" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `close` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/core/fia.py#L1464" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 close(self)

--- a/docs/api/pyfia-estimation-estimators-area.mdx
+++ b/docs/api/pyfia-estimation-estimators-area.mdx
@@ -111,18 +111,21 @@ If False, only return per-acre values.
     Inventory year
 - **[grouping columns]** : varies
     Any columns specified in grp_by parameter
-- **AREA_PCT** : float
-    Percentage of total area
-- **AREA_SE** : float (if variance=False)
-    Standard error of area percentage
-- **AREA_VAR** : float (if variance=True)
-    Variance of area percentage
+- **AREA_PERC** : float
+    Percentage of the sampled area in the requested land/condition
+    class
+- **AREA_SE_PERCENT** : float
+    Standard error of AREA_PERC (the percentage)
+- **AREA** : float
+    Total area in acres, expanded to the population
+- **AREA_SE** : float
+    Standard error of AREA (the total, in acres)
+- **AREA_VARIANCE** : float
+    Variance of the total area in acres (equals AREA_SE squared)
+- **TOTAL_EXPNS** : float
+    Total expansion factor (population acres) for the evaluation
 - **N_PLOTS** : int
-    Number of plots in estimate
-- **AREA** : float (if totals=True)
-    Total area in acres
-- **AREA_TOTAL_SE** : float (if totals=True and variance=False)
-    Standard error of total area
+    Number of plots contributing to the estimate
 
 
 **Examples:**

--- a/docs/api/pyfia-estimation-estimators-growth.mdx
+++ b/docs/api/pyfia-estimation-estimators-growth.mdx
@@ -16,7 +16,7 @@ TREE_GRM_BEGIN tables following EVALIDator approach.
 
 ## Functions
 
-### `growth` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L527" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `growth` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L522" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 growth(db: str | FIA, grp_by: str | list[str] | None = None, by_species: bool = False, by_size_class: bool = False, size_class_type: str = 'standard', land_type: str = 'forest', tree_type: str = 'gs', measure: str = 'volume', tree_domain: str | None = None, area_domain: str | None = None, totals: bool = True, variance: bool = False, most_recent: bool = False) -> pl.DataFrame
@@ -86,16 +86,7 @@ component_type(self) -> Literal['growth', 'mortality', 'removals']
 Return 'growth' as the GRM component type.
 
 
-#### `get_cond_columns` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L39" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
-
-```python
-get_cond_columns(self) -> list[str]
-```
-
-Required condition columns for growth estimation.
-
-
-#### `load_data` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L63" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `load_data` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L44" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_data(self) -> pl.LazyFrame | None
@@ -107,7 +98,7 @@ Growth requires complex join pattern with BEGINEND cross-join.
 Cannot use the simple GRM loading pattern.
 
 
-#### `apply_filters` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L272" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `apply_filters` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L267" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 apply_filters(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -119,7 +110,7 @@ CRITICAL: Include ALL components for BEGINEND cross-join methodology.
 Do NOT filter by COND_STATUS_CD - GRM columns already handle land basis.
 
 
-#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L307" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L302" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_values(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -133,7 +124,7 @@ Implements EVALIDator's ONEORTWO logic:
 Sum across ONEORTWO rows gives NET growth = ending - beginning
 
 
-#### `aggregate_results` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L404" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `aggregate_results` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L399" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 aggregate_results(self, data: pl.LazyFrame | None) -> AggregationResult
@@ -146,7 +137,7 @@ Aggregate growth with two-stage aggregation.
 explicit variance calculation.
 
 
-#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L476" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L471" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_variance(self, agg_result: AggregationResult) -> pl.DataFrame
@@ -164,7 +155,7 @@ aggregate_results().
 - Results with variance columns added.
 
 
-#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L518" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/growth.py#L513" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 format_output(self, results: pl.DataFrame) -> pl.DataFrame

--- a/docs/concepts/variance.mdx
+++ b/docs/concepts/variance.mdx
@@ -44,12 +44,18 @@ where for each stratum $h$:
 
 ## Reading the output
 
-By default, estimators return standard-error columns (suffix `_SE`). Pass `variance=True` to get variances (suffix `_VAR`) instead:
+Estimators always return **both** standard-error columns (suffix `_SE`) and variance columns. The standard errors are prefixed with the measure (e.g. `VOLCFNET_TOTAL_SE`), while the variance columns use generic names — `VOLUME_ACRE_VARIANCE` / `VOLUME_TOTAL_VARIANCE` for tree estimates and `AREA_VARIANCE` for area. The variance always equals the corresponding standard error squared:
 
 ```python
-volume(db, totals=True)                  # ...VOLCFNET_TOTAL, VOLCFNET_TOTAL_SE
-volume(db, totals=True, variance=True)   # ...VOLCFNET_TOTAL, VOLCFNET_TOTAL_VAR
+volume(db, totals=True)
+# ...VOLCFNET_TOTAL, VOLCFNET_TOTAL_SE, VOLUME_TOTAL_VARIANCE
 ```
+
+<Note>
+  The `variance=True` parameter currently has **no effect** — both the `_SE`
+  and variance columns are returned regardless of its value (tracked in
+  [#109](https://github.com/mihiarc/pyfia/issues/109)).
+</Note>
 
 There are no separate confidence-interval columns — construct one from the estimate and its standard error (for a 95% interval, ±1.96 × SE).
 

--- a/docs/concepts/variance.mdx
+++ b/docs/concepts/variance.mdx
@@ -44,17 +44,21 @@ where for each stratum $h$:
 
 ## Reading the output
 
-Estimators always return **both** standard-error columns (suffix `_SE`) and variance columns. The standard errors are prefixed with the measure (e.g. `VOLCFNET_TOTAL_SE`), while the variance columns use generic names — `VOLUME_ACRE_VARIANCE` / `VOLUME_TOTAL_VARIANCE` for tree estimates and `AREA_VARIANCE` for area. The variance always equals the corresponding standard error squared:
+Every estimate includes standard-error columns (suffix `_SE`) — for example `VOLCFNET_TOTAL_SE` for volume or `AREA_SE` for area. In addition, `area()` and `volume()` emit variance columns (`AREA_VARIANCE`; `VOLUME_ACRE_VARIANCE` and `VOLUME_TOTAL_VARIANCE`), each equal to the corresponding standard error squared. The other estimators currently return standard errors only:
 
 ```python
 volume(db, totals=True)
 # ...VOLCFNET_TOTAL, VOLCFNET_TOTAL_SE, VOLUME_TOTAL_VARIANCE
+biomass(db, totals=True)
+# ...BIO_TOTAL, BIO_TOTAL_SE   (standard errors only)
 ```
 
 <Note>
-  The `variance=True` parameter currently has **no effect** — both the `_SE`
-  and variance columns are returned regardless of its value (tracked in
-  [#109](https://github.com/mihiarc/pyfia/issues/109)).
+  Avoid the `variance=True` parameter — it does **not** reliably switch the
+  output from standard errors to variances. For most estimators it has no
+  effect, and for `tpa()` it currently drops the standard-error columns
+  entirely. Use the `_SE` columns (and the `*_VARIANCE` columns where present)
+  directly. Tracked in [#109](https://github.com/mihiarc/pyfia/issues/109).
 </Note>
 
 There are no separate confidence-interval columns — construct one from the estimate and its standard error (for a 95% interval, ±1.96 × SE).

--- a/docs/examples.mdx
+++ b/docs/examples.mdx
@@ -85,7 +85,7 @@ print(f"Aboveground biomass: {result['BIO_TOTAL'][0]:,.0f} tons")
 print(f"Carbon:              {result['CARB_TOTAL'][0]:,.0f} tons")
 ```
 
-Components: `"AG"` (aboveground, default), `"BG"` (belowground), `"TOTAL"`, `"STEM"`, `"STUMP"`, `"TOP"`, `"FOLIAGE"`.
+Components: `"AG"` (aboveground, default), `"BG"` (belowground), `"TOTAL"`, `"BOLE"`, `"BRANCH"`, `"FOLIAGE"` (case-insensitive).
 
 ## Custom domain filtering
 
@@ -130,7 +130,7 @@ result = validate_pyfia_estimate(
     year=2023,
     estimate_type="volume",
 )
-print(f"Difference: {result.percent_difference:.2f}%")
+print(f"Difference: {result.pct_diff:.2f}%")
 ```
 
 See [`validate_pyfia_estimate()`](/api/pyfia-evalidator-validation) for the full signature.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -84,9 +84,9 @@ By the end you'll have downloaded FIA data, selected a valid evaluation, estimat
     Other estimators follow the same pattern with their own prefixes — `VOLCFNET_ACRE`
     and `VOLCFNET_TOTAL` for [`volume()`](/api/pyfia-estimation-estimators-volume),
     `MORT_ACRE` for [`mortality()`](/api/pyfia-estimation-estimators-mortality), and so
-    on. Every estimate also includes a variance column (e.g. `AREA_VARIANCE`) alongside
-    the `_SE` columns — see [Understanding variance](/concepts/variance). Pass
-    `totals=False` to drop the population totals.
+    on. Every estimate comes with standard-error columns (suffix `_SE`); `area()` and
+    `volume()` also include variance columns — see [Understanding variance](/concepts/variance).
+    Pass `totals=False` to drop the population totals.
   </Step>
 </Steps>
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -75,16 +75,18 @@ By the end you'll have downloaded FIA data, selected a valid evaluation, estimat
     | Column | Meaning |
     |--------|---------|
     | `AREA` | Total area in acres |
-    | `AREA_PCT` | Percentage of the sampled area |
-    | `AREA_SE` | Standard error of the percentage |
+    | `AREA_SE` | Standard error of `AREA` (the total, in acres) |
+    | `AREA_PERC` | Percentage of the sampled area |
+    | `AREA_SE_PERCENT` | Standard error of `AREA_PERC` (the percentage) |
     | `N_PLOTS` | Plots contributing to the estimate |
     | `YEAR` | Inventory year |
 
     Other estimators follow the same pattern with their own prefixes — `VOLCFNET_ACRE`
     and `VOLCFNET_TOTAL` for [`volume()`](/api/pyfia-estimation-estimators-volume),
     `MORT_ACRE` for [`mortality()`](/api/pyfia-estimation-estimators-mortality), and so
-    on. Pass `variance=True` to get variances instead of standard errors; `totals=False`
-    to drop the population totals.
+    on. Every estimate also includes a variance column (e.g. `AREA_VARIANCE`) alongside
+    the `_SE` columns — see [Understanding variance](/concepts/variance). Pass
+    `totals=False` to drop the population totals.
   </Step>
 </Steps>
 

--- a/docs/guides/spatial.mdx
+++ b/docs/guides/spatial.mdx
@@ -79,7 +79,7 @@ with FIA("southeast.duckdb") as db:
 ## Method signatures
 
 ```python
-db.clip_by_polygon(polygon: str | Path) -> FIA
+db.clip_by_polygon(polygon: str | Path, predicate: str = "intersects") -> FIA
 db.intersect_polygons(polygon: str | Path, attributes: list[str]) -> FIA
 ```
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -67,7 +67,7 @@ with FIA(db_path) as db:
 
 ## Coming from rFIA?
 
-pyFIA brings the ergonomics of R's [rFIA](https://rfia.netlify.app/) to Python:
+pyFIA brings the ergonomics of R's [rFIA](https://doserlab.com/files/rfia/) to Python:
 
 | Task | rFIA (R) | pyFIA (Python) |
 |------|----------|----------------|

--- a/src/pyfia/estimation/estimators/area.py
+++ b/src/pyfia/estimation/estimators/area.py
@@ -686,18 +686,21 @@ def area(
             Inventory year
         - **[grouping columns]** : varies
             Any columns specified in grp_by parameter
-        - **AREA_PCT** : float
-            Percentage of total area
-        - **AREA_SE** : float (if variance=False)
-            Standard error of area percentage
-        - **AREA_VAR** : float (if variance=True)
-            Variance of area percentage
+        - **AREA_PERC** : float
+            Percentage of the sampled area in the requested land/condition
+            class
+        - **AREA_SE_PERCENT** : float
+            Standard error of AREA_PERC (the percentage)
+        - **AREA** : float
+            Total area in acres, expanded to the population
+        - **AREA_SE** : float
+            Standard error of AREA (the total, in acres)
+        - **AREA_VARIANCE** : float
+            Variance of the total area in acres (equals AREA_SE squared)
+        - **TOTAL_EXPNS** : float
+            Total expansion factor (population acres) for the evaluation
         - **N_PLOTS** : int
-            Number of plots in estimate
-        - **AREA** : float (if totals=True)
-            Total area in acres
-        - **AREA_TOTAL_SE** : float (if totals=True and variance=False)
-            Standard error of total area
+            Number of plots contributing to the estimate
 
     See Also
     --------

--- a/src/pyfia/estimation/estimators/growth.py
+++ b/src/pyfia/estimation/estimators/growth.py
@@ -558,7 +558,7 @@ def growth(
         - "market": Timber market categories (Pulpwood, Chip-n-Saw, Sawtimber)
     land_type : {'forest', 'timber'}, default 'forest'
         Land type to include in estimation.
-    tree_type : {'gs', 'al', 'sl'}, default 'gs'
+    tree_type : {'all', 'dead', 'gs', 'live'}, default 'gs'
         Tree type to include.
     measure : {'volume', 'biomass', 'count'}, default 'volume'
         What to measure in the growth estimation.

--- a/src/pyfia/estimation/estimators/mortality.py
+++ b/src/pyfia/estimation/estimators/mortality.py
@@ -299,7 +299,7 @@ def mortality(
         - "market": Timber market categories (Pre-merchantable, Pulpwood, Chip-n-Saw, Sawtimber)
     land_type : {'forest', 'timber'}, default 'timber'
         Land type to include in estimation.
-    tree_type : {'gs', 'al', 'sawtimber', 'live'}, default 'gs'
+    tree_type : {'all', 'dead', 'gs', 'live'}, default 'gs'
         Tree type to include.
     measure : {'volume', 'sawlog', 'biomass', 'tpa', 'count', 'basal_area'}, default 'volume'
         What to measure in the mortality estimation.
@@ -361,8 +361,8 @@ def mortality(
     **Pre-merchantable Tree Support:**
     By default (``tree_type="gs"``), only growing stock trees (≥5" DBH) are
     included. To include pre-merchantable trees (1.0"-4.9" DBH), use
-    ``tree_type="live"`` or ``tree_type="al"``. When using market size classes,
-    pre-merchantable trees are automatically categorized as "Pre-merchantable".
+    ``tree_type="live"``. When using market size classes, pre-merchantable
+    trees are automatically categorized as "Pre-merchantable".
 
     Note that FIA does not calculate volume for trees < 5" DBH, so
     ``measure="tpa"`` is recommended for pre-merchantable mortality analysis.


### PR DESCRIPTION
## Summary

Docs-only fixes from the **v1.4.1 public-docs audit**, so the published site (pyfia.mintlify.app) matches shipped 1.4.1 behavior. No estimation math, signatures, or output columns change — only docstrings and `.mdx` content. Every fix was verified against a real FIA database (Georgia, FIPS 13).

## User-facing guide fixes (`docs/*.mdx`)

| File | Fix |
|------|-----|
| `examples.mdx` | Biomass component list dropped the invalid `STEM`/`STUMP`/`TOP` (raise `ValueError`) → `AG, BG, TOTAL, BOLE, BRANCH, FOLIAGE`. |
| `examples.mdx` | `ValidationResult` attribute is `pct_diff`, not `percent_difference` (`AttributeError`). |
| `getting-started.mdx` | `area()` percentage column is `AREA_PERC`, not `AREA_PCT`; `AREA_SE` is the SE of **total acres** (added an `AREA_SE_PERCENT` row for the percentage SE). |
| `getting-started.mdx` + `concepts/variance.mdx` | Estimators always return both `_SE` and variance columns (`VOLUME_*_VARIANCE` / `AREA_VARIANCE`); the `variance=True` flag is currently a no-op (#109), so the `variance=True`/`_VAR` claim is dropped. |
| `guides/spatial.mdx` | `clip_by_polygon` signature now shows `predicate="intersects"`. |
| `index.mdx` | rFIA link normalized to the canonical `doserlab.com` URL. |

## API reference (`docs/api/*.mdx`, regenerated via `scripts/gen_api_docs.sh`)

- **`area()` Returns block** rewritten to the real columns (`AREA_PERC`, `AREA_SE` = SE of total acres, `AREA_SE_PERCENT`, `AREA_VARIANCE`, `AREA`, `TOTAL_EXPNS`, `N_PLOTS`); dropped the non-existent `AREA_PCT`/`AREA_VAR`/`AREA_TOTAL_SE` rows. **Closes #112.**
- **`mortality()`/`growth()` `tree_type`** corrected to `{all, dead, gs, live}` to match `validate_tree_type`; dropped `al`/`sl`/`sawtimber` and the `tree_type="al"` reference in mortality's Notes. **Addresses the docstring half of #111.** (Note: mdxify renders NumPy `Returns` blocks but not `Parameters` type-annotations, so this corrects the source docstrings — what users see in `help()`/IDEs — without an `.mdx` diff for those two pages.)
- The regen also picks up the corrected `eval_type` token lists in `FIA.find_evalid`/`clip_most_recent` (the stale pre-1.4.1 `'GRM' for growth` text) plus source drift in `core/fia` and the growth estimator.

## Verification

- `git diff --stat docs/api/` limited to 3 intended pages (`pyfia-core-fia`, `area`, `growth`); 17 pages total, no NSVB carbon leak, no dropped pages.
- Ran touched examples on `data/georgia.duckdb`: `area()` emits `AREA_PERC`; biomass components `AG/BG/TOTAL/BOLE/BRANCH/FOLIAGE` all work; `ValidationResult.pct_diff` exists; `tree_type` `{all,dead,gs,live}` accepted while `al`/`sl`/`sawtimber` correctly raise.

The remaining code-level questions (whether `variance=True` should be honored, `ROOT` biomass, whether the validator should accept `sawtimber`) stay tracked in #109, #110, and the code half of #111.
