### PR TITLE
fix: estimator validation + variance output bugs (#109, #110, #111); release 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ live-tree-stock implementations (#89).
 - **Woodland-species biomass collapse** in `live_tree()`; **woodland-species zeroing** in `standing_dead()` (shared guard in the carbon estimator base class).
 - DECAYCD empty-string filter leak in the standing-dead path.
 
+## [1.4.2] - 2026-06-30
+
+Bug-fix release closing three estimator issues found in the v1.4.1 public-docs
+audit (#109, #110, #111). Point estimates and standard errors are unchanged for
+every previously-working query; the changes concern input validation and the
+opt-in variance columns only.
+
+### Fixed
+- **`biomass(component="ROOT")` crashed with a `BinderException`** (#110) — `"root"` passed validation but then selected a non-existent `DRYBIO_ROOT` column. `"root"` has been removed from the valid component set; use `"bg"` for belowground/coarse-root biomass (`DRYBIO_BG`). Valid components are `AG`, `BG`, `TOTAL`, `BOLE`, `BRANCH`, `FOLIAGE` (case-insensitive).
+- **GRM estimators rejected the `tree_type` values they actually support** (#111) — `growth()`/`mortality()`/`removals()` advertise and internally handle `gs`/`al`/`sl`/`live`/`sawtimber`, but the shared validator only allowed `{all, dead, gs, live}`, so following the documented API raised `ValueError`. These estimators now validate against `{gs, al, sl, live, sawtimber}` (`al`/`live` → all-live, `sl`/`sawtimber` → sawtimber-size). `area()`/`volume()`/`biomass()`/`tpa()` keep `{all, dead, gs, live}`.
+- **`variance=True` did not add variance columns (and broke `tpa()`)** (#109) — the flag was a no-op for most estimators, and for `tpa()` it dropped the standard-error columns entirely. Standard errors (`*_SE`) are now always returned, and `variance=True` adds matching `*_VARIANCE` columns (equal to the standard error squared) uniformly across every estimator.
+
+### Changed
+- **The standard-error / variance output contract is now uniform and opt-in.** `area()` and `volume()` no longer emit variance columns by default — pass `variance=True`. Variance columns use the standard-error-mirrored name (e.g. `VOLCFNET_TOTAL_SE` → `VOLCFNET_TOTAL_VARIANCE`, `AREA_SE_PERCENT` → `AREA_VARIANCE_PERCENT`); `tpa()`'s previous `*_VAR` columns are renamed to `*_VARIANCE`.
+- **GRM estimators no longer silently accept `tree_type="all"`/`"dead"`** (part of #111) — these previously fell through to growing stock; they now raise a clear `ValueError`.
+
 ## [1.4.1] - 2026-06-30
 
 Bug-fix release for the Growth-Removal-Mortality (GRM) / condition-column paths,

--- a/docs/api/pyfia-estimation-estimators-area.mdx
+++ b/docs/api/pyfia-estimation-estimators-area.mdx
@@ -100,7 +100,8 @@ state/region. Equivalent to calling db.clip_most_recent() first.
 - `eval_type`: Evaluation type to select if most_recent=True. Options\:
 'ALL', 'VOL', 'GROW', 'MORT', 'REMV', 'CHANGE', 'DWM', 'INV'.
 Default is 'ALL' for area estimation.
-- `variance`: If True, return variance instead of standard error.
+- `variance`: If True, also return variance columns (``*_VARIANCE``) alongside the
+standard errors (``*_SE``, always returned). Variance = SE squared.
 - `totals`: If True, include total area estimates expanded to population level.
 If False, only return per-acre values.
 
@@ -120,8 +121,10 @@ If False, only return per-acre values.
     Total area in acres, expanded to the population
 - **AREA_SE** : float
     Standard error of AREA (the total, in acres)
-- **AREA_VARIANCE** : float
+- **AREA_VARIANCE** : float (if variance=True)
     Variance of the total area in acres (equals AREA_SE squared)
+- **AREA_VARIANCE_PERCENT** : float (if variance=True)
+    Variance of the percentage (equals AREA_SE_PERCENT squared)
 - **TOTAL_EXPNS** : float
     Total expansion factor (population acres) for the evaluation
 - **N_PLOTS** : int

--- a/docs/api/pyfia-estimation-estimators-biomass.mdx
+++ b/docs/api/pyfia-estimation-estimators-biomass.mdx
@@ -67,7 +67,7 @@ defined as\: 1.0-4.9", 5.0-9.9", 10.0-19.9", 20.0-29.9", 30.0+".
 - 'gs'\: Growing stock trees (live, merchantable, STATUSCD == 1 with
   specific quality requirements)
 - 'all'\: All trees regardless of status
-- `component`: Biomass component to estimate. Valid options include\:
+- `component`: Biomass component to estimate (case-insensitive)\:
 
 - 'AG'\: Aboveground biomass (stem, bark, branches, foliage)
 - 'BG'\: Belowground biomass (coarse roots)
@@ -75,20 +75,18 @@ defined as\: 1.0-4.9", 5.0-9.9", 10.0-19.9", 20.0-29.9", 30.0+".
 - 'BOLE'\: Main stem wood and bark
 - 'BRANCH'\: Live and dead branches
 - 'FOLIAGE'\: Leaves/needles
-- 'ROOTS'\: Coarse roots (same as BG)
-- 'STUMP'\: Stump biomass
-- 'SAPLING'\: Sapling biomass
-- 'TOP'\: Top and branches above merchantable height
 
-Note\: Not all components may be available for all species or regions.
-Check TREE table for available DRYBIO_* columns.
+For belowground/coarse-root biomass use 'BG'. Each value maps to a
+DRYBIO_* column in the TREE table; values without a corresponding
+column (e.g. 'ROOT', 'STUMP', 'TOP') are not supported.
 - `tree_domain`: SQL-like filter expression for tree-level filtering. Applied to
 TREE table. Example\: "DIA >= 10.0 AND SPCD == 131".
 - `area_domain`: SQL-like filter expression for area/condition-level filtering.
 Applied to COND table. Example\: "OWNGRPCD == 40 AND FORTYPCD == 161".
 - `totals`: If True, include population-level total estimates in addition to
 per-acre values. Totals are expanded using FIA expansion factors.
-- `variance`: If True, calculate and include variance and standard error estimates.
+- `variance`: If True, also return variance columns (``*_VARIANCE``) alongside the
+standard errors (``*_SE``, always returned). Variance = SE squared.
 Note\: Currently uses simplified variance calculation (10% of estimate).
 - `most_recent`: If True, automatically filter to the most recent evaluation for
 each state in the database before estimation.
@@ -104,14 +102,16 @@ each state in the database before estimation.
     Carbon per acre in tons (47% of biomass)
 - **CARB_TOTAL** : float (if totals=True)
     Total carbon in tons expanded to population level
-- **BIO_ACRE_SE** : float (if variance=True)
+- **BIO_ACRE_SE** : float
     Standard error of per-acre biomass estimate
-- **BIO_TOTAL_SE** : float (if variance=True and totals=True)
+- **BIO_TOTAL_SE** : float (if totals=True)
     Standard error of total biomass estimate
-- **CARB_ACRE_SE** : float (if variance=True)
+- **CARB_ACRE_SE** : float
     Standard error of per-acre carbon estimate
-- **CARB_TOTAL_SE** : float (if variance=True and totals=True)
+- **CARB_TOTAL_SE** : float (if totals=True)
     Standard error of total carbon estimate
+- **BIO_ACRE_VARIANCE**, **BIO_TOTAL_VARIANCE**, **CARB_ACRE_VARIANCE**, **CARB_TOTAL_VARIANCE** : float (if variance=True)
+    Variance of the corresponding estimate (= the matching _SE squared)
 - **AREA_TOTAL** : float
     Total area (acres) represented by the estimation
 - **N_PLOTS** : int

--- a/docs/api/pyfia-estimation-estimators-growth.mdx
+++ b/docs/api/pyfia-estimation-estimators-growth.mdx
@@ -39,19 +39,27 @@ methodology.
 - "descriptive"\: Text labels (Saplings, Small, Medium, Large)
 - "market"\: Timber market categories (Pulpwood, Chip-n-Saw, Sawtimber)
 - `land_type`: Land type to include in estimation.
-- `tree_type`: Tree type to include.
+- `tree_type`: Tree population to include (GRM tables)\:
+
+- 'gs'\: growing stock
+- 'al' or 'live'\: all live trees
+- 'sl' or 'sawtimber'\: sawtimber-size trees
 - `measure`: What to measure in the growth estimation.
 - `tree_domain`: SQL-like filter expression for tree-level filtering.
 - `area_domain`: SQL-like filter expression for area/condition-level filtering.
 - `totals`: If True, include population-level total estimates.
-- `variance`: If True, calculate and include variance and standard error estimates.
+- `variance`: If True, also return variance columns (``*_VARIANCE``) alongside the
+standard errors (``*_SE``, always returned). Variance = SE squared.
 - `most_recent`: If True, automatically filter to the most recent evaluation.
 
 **Returns:**
 - Growth estimates with columns:
 - GROWTH_ACRE: Annual growth per acre
 - GROWTH_TOTAL: Total annual growth (if totals=True)
-- GROWTH_ACRE_SE: Standard error of per-acre estimate (if variance=True)
+- GROWTH_ACRE_SE: Standard error of per-acre estimate
+- GROWTH_TOTAL_SE: Standard error of total estimate (if totals=True)
+- GROWTH_ACRE_VARIANCE, GROWTH_TOTAL_VARIANCE: Variance of the estimates,
+  equal to the matching _SE squared (if variance=True)
 - Additional grouping columns if specified
 
 

--- a/docs/api/pyfia-estimation-estimators-mortality.mdx
+++ b/docs/api/pyfia-estimation-estimators-mortality.mdx
@@ -38,21 +38,28 @@ This is the correct FIA statistical methodology for mortality estimation.
 - "descriptive"\: Text labels (Saplings, Small, Medium, Large)
 - "market"\: Timber market categories (Pre-merchantable, Pulpwood, Chip-n-Saw, Sawtimber)
 - `land_type`: Land type to include in estimation.
-- `tree_type`: Tree type to include.
+- `tree_type`: Tree population to include (GRM tables)\:
+
+- 'gs'\: growing stock
+- 'al' or 'live'\: all live trees
+- 'sl' or 'sawtimber'\: sawtimber-size trees
 - `measure`: What to measure in the mortality estimation.
 - `tree_domain`: SQL-like filter expression for tree-level filtering.
 - `area_domain`: SQL-like filter expression for area/condition-level filtering.
 - `as_rate`: If True, return mortality as a rate (mortality/live).
 - `totals`: If True, include population-level total estimates.
-- `variance`: If True, calculate and include variance and standard error estimates.
+- `variance`: If True, also return variance columns (``*_VARIANCE``) alongside the
+standard errors (``*_SE``, always returned). Variance = SE squared.
 - `most_recent`: If True, automatically filter to the most recent evaluation.
 
 **Returns:**
 - Mortality estimates with columns:
 - MORT_ACRE: Annual mortality per acre
 - MORT_TOTAL: Total annual mortality (if totals=True)
-- MORT_ACRE_SE: Standard error of per-acre estimate (if variance=True)
-- MORT_TOTAL_SE: Standard error of total estimate (if variance=True)
+- MORT_ACRE_SE: Standard error of per-acre estimate
+- MORT_TOTAL_SE: Standard error of total estimate (if totals=True)
+- MORT_ACRE_VARIANCE, MORT_TOTAL_VARIANCE: Variance of the estimates,
+  equal to the matching _SE squared (if variance=True)
 - Additional grouping columns if specified
 
 

--- a/docs/api/pyfia-estimation-estimators-removals.mdx
+++ b/docs/api/pyfia-estimation-estimators-removals.mdx
@@ -37,7 +37,8 @@ growing-stock trees (at least 5 inches d.b.h.) on forest land.
 - "descriptive"\: Text labels (Saplings, Small, Medium, Large)
 - "market"\: Timber market categories (Pulpwood, Chip-n-Saw, Sawtimber)
 - `land_type`: Land type\: "forest", "timber", or "all"
-- `tree_type`: Tree type\: "gs" (growing stock), "all"
+- `tree_type`: Tree population to include (GRM tables)\: 'gs' (growing stock),
+'al'/'live' (all live), 'sl'/'sawtimber' (sawtimber-size).
 - `measure`: What to measure\: "volume", "biomass", or "count"
 - `tree_domain`: SQL-like filter for trees
 - `area_domain`: SQL-like filter for area

--- a/docs/api/pyfia-estimation-estimators-tpa.mdx
+++ b/docs/api/pyfia-estimation-estimators-tpa.mdx
@@ -15,7 +15,7 @@ without unnecessary abstractions.
 
 ## Functions
 
-### `tpa` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/tpa.py#L359" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `tpa` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/tpa.py#L337" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 tpa(db: 'FIA', grp_by: str | list[str] | None = None, by_species: bool = False, by_size_class: bool = False, land_type: str = 'forest', tree_type: str = 'live', tree_domain: str | None = None, area_domain: str | None = None, plot_domain: str | None = None, totals: bool = False, variance: bool = False) -> pl.DataFrame
@@ -100,8 +100,9 @@ Applied to the COND table. Examples\:
 - `totals`: If True, include population-level total estimates (TPA_TOTAL, BAA_TOTAL)
 in addition to per-acre values. Total estimates are expanded using
 stratification factors.
-- `variance`: If True, return variance instead of standard error. Standard error
-is calculated as the square root of variance.
+- `variance`: If True, also return variance columns (``*_VARIANCE``) alongside the
+standard errors. Standard errors (``*_SE``) are always returned;
+variance equals the standard error squared.
 
 **Returns:**
 - Trees per acre and basal area estimates with the following columns:
@@ -114,22 +115,22 @@ is calculated as the square root of variance.
     Trees per acre
 - **BAA** : float
     Basal area per acre (square feet)
-- **TPA_SE** : float (if variance=False)
+- **TPA_SE** : float
     Standard error of TPA estimate
-- **BAA_SE** : float (if variance=False)
+- **BAA_SE** : float
     Standard error of BAA estimate
-- **TPA_VAR** : float (if variance=True)
-    Variance of TPA estimate
-- **BAA_VAR** : float (if variance=True)
-    Variance of BAA estimate
+- **TPA_VARIANCE**, **BAA_VARIANCE** : float (if variance=True)
+    Variance of the per-acre estimates (= the SE columns squared)
 - **TPA_TOTAL** : float (if totals=True)
     Total trees expanded to population level
 - **BAA_TOTAL** : float (if totals=True)
     Total basal area expanded to population level
-- **TPA_TOTAL_SE** : float (if totals=True and variance=False)
+- **TPA_TOTAL_SE** : float (if totals=True)
     Standard error of total TPA
-- **BAA_TOTAL_SE** : float (if totals=True and variance=False)
+- **BAA_TOTAL_SE** : float (if totals=True)
     Standard error of total BAA
+- **TPA_TOTAL_VARIANCE**, **BAA_TOTAL_VARIANCE** : float (if totals=True and variance=True)
+    Variance of the totals (= the total SE columns squared)
 - **N_PLOTS** : int
     Number of FIA plots in estimate
 - **N_TREES** : int
@@ -295,7 +296,7 @@ V(Ŷ) = Σ_h w_h² × s²_yh × n_h
 This matches EVALIDator's variance calculation for tree-based estimates.
 
 
-#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/tpa.py#L275" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/tpa.py#L260" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 format_output(self, results: pl.DataFrame) -> pl.DataFrame

--- a/docs/api/pyfia-estimation-estimators-volume.mdx
+++ b/docs/api/pyfia-estimation-estimators-volume.mdx
@@ -113,7 +113,8 @@ defined as\: 1.0-4.9", 5.0-9.9", 10.0-19.9", 20.0-29.9", 30.0+".
 - "SLOPE < 30 AND ASPECT BETWEEN 135 AND 225"\: Gentle south-facing slopes
 - `totals`: If True, include total volume estimates expanded to population level.
 If False, only return per-acre values.
-- `variance`: If True, return variance instead of standard error.
+- `variance`: If True, also return variance columns (``*_VARIANCE``) alongside the
+standard errors (``*_SE``, always returned). Variance = SE squared.
 - `most_recent`: If True, automatically select the most recent evaluation for each
 state/region. Equivalent to calling db.clip_most_recent() first.
 - `eval_type`: Evaluation type to select if most_recent=True. Options\:
@@ -135,10 +136,10 @@ Default is 'VOL' for volume estimation.
     Sound cubic foot volume per acre
 - **VOLBFNET_ACRE** : float (if vol_type='sawlog')
     Net board foot volume per acre
-- **VOLCFNET_ACRE_SE** : float (if variance=False)
+- **VOLCFNET_ACRE_SE** : float
     Standard error of per-acre volume estimate
-- **VOLCFNET_ACRE_VAR** : float (if variance=True)
-    Variance of per-acre volume estimate
+- **VOLCFNET_ACRE_VARIANCE** : float (if variance=True)
+    Variance of per-acre volume estimate (= VOLCFNET_ACRE_SE squared)
 - **N_PLOTS** : int
     Number of plots in estimate
 - **N_TREES** : int
@@ -147,8 +148,10 @@ Default is 'VOL' for volume estimation.
     Total area (acres) represented by the estimation
 - **VOLCFNET_TOTAL** : float (if totals=True)
     Total volume expanded to population level
-- **VOLCFNET_TOTAL_SE** : float (if totals=True and variance=False)
+- **VOLCFNET_TOTAL_SE** : float (if totals=True)
     Standard error of total volume
+- **VOLCFNET_TOTAL_VARIANCE** : float (if totals=True and variance=True)
+    Variance of total volume (= VOLCFNET_TOTAL_SE squared)
 
 
 **Examples:**

--- a/docs/concepts/variance.mdx
+++ b/docs/concepts/variance.mdx
@@ -44,22 +44,15 @@ where for each stratum $h$:
 
 ## Reading the output
 
-Every estimate includes standard-error columns (suffix `_SE`) — for example `VOLCFNET_TOTAL_SE` for volume or `AREA_SE` for area. In addition, `area()` and `volume()` emit variance columns (`AREA_VARIANCE`; `VOLUME_ACRE_VARIANCE` and `VOLUME_TOTAL_VARIANCE`), each equal to the corresponding standard error squared. The other estimators currently return standard errors only:
+Every estimate includes standard-error columns (suffix `_SE`) — for example `VOLCFNET_TOTAL_SE` for volume or `AREA_SE` for area. Pass `variance=True` to additionally get the matching variance columns (suffix `_VARIANCE`), each equal to the corresponding standard error squared. Standard errors are always returned; the variance columns are opt-in and behave the same way across every estimator:
 
 ```python
 volume(db, totals=True)
-# ...VOLCFNET_TOTAL, VOLCFNET_TOTAL_SE, VOLUME_TOTAL_VARIANCE
-biomass(db, totals=True)
-# ...BIO_TOTAL, BIO_TOTAL_SE   (standard errors only)
-```
+# ...VOLCFNET_TOTAL, VOLCFNET_TOTAL_SE
 
-<Note>
-  Avoid the `variance=True` parameter — it does **not** reliably switch the
-  output from standard errors to variances. For most estimators it has no
-  effect, and for `tpa()` it currently drops the standard-error columns
-  entirely. Use the `_SE` columns (and the `*_VARIANCE` columns where present)
-  directly. Tracked in [#109](https://github.com/mihiarc/pyfia/issues/109).
-</Note>
+volume(db, totals=True, variance=True)
+# ...VOLCFNET_TOTAL, VOLCFNET_TOTAL_SE, VOLCFNET_TOTAL_VARIANCE
+```
 
 There are no separate confidence-interval columns — construct one from the estimate and its standard error (for a 95% interval, ±1.96 × SE).
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -84,9 +84,10 @@ By the end you'll have downloaded FIA data, selected a valid evaluation, estimat
     Other estimators follow the same pattern with their own prefixes — `VOLCFNET_ACRE`
     and `VOLCFNET_TOTAL` for [`volume()`](/api/pyfia-estimation-estimators-volume),
     `MORT_ACRE` for [`mortality()`](/api/pyfia-estimation-estimators-mortality), and so
-    on. Every estimate comes with standard-error columns (suffix `_SE`); `area()` and
-    `volume()` also include variance columns — see [Understanding variance](/concepts/variance).
-    Pass `totals=False` to drop the population totals.
+    on. Every estimate comes with standard-error columns (suffix `_SE`); pass
+    `variance=True` to also get the matching `_VARIANCE` columns — see
+    [Understanding variance](/concepts/variance). Pass `totals=False` to drop the
+    population totals.
   </Step>
 </Steps>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyfia"
-version = "1.4.1"
+version = "1.4.2"
 description = "High-performance Python library for Forest Inventory and Analysis (FIA) data analysis"
 readme = "README.md"
 authors = [

--- a/src/pyfia/estimation/base.py
+++ b/src/pyfia/estimation/base.py
@@ -32,6 +32,7 @@ from .aggregation import (
     compute_per_acre_values as _compute_per_acre_values_impl,
 )
 from .data_loading import DataLoader
+from .utils import apply_variance_columns
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +130,11 @@ class BaseEstimator(ABC):
         results = self.calculate_variance(agg_result)
 
         # 6. Format output
-        return self.format_output(results)
+        formatted = self.format_output(results)
+
+        # 7. Apply the standard-error / variance column contract uniformly:
+        #    always keep _SE columns; add _VARIANCE columns only if requested.
+        return apply_variance_columns(formatted, self.config.get("variance", False))
 
     def load_data(self) -> pl.LazyFrame | None:
         """

--- a/src/pyfia/estimation/estimators/area.py
+++ b/src/pyfia/estimation/estimators/area.py
@@ -672,7 +672,8 @@ def area(
         'ALL', 'VOL', 'GROW', 'MORT', 'REMV', 'CHANGE', 'DWM', 'INV'.
         Default is 'ALL' for area estimation.
     variance : bool, default False
-        If True, return variance instead of standard error.
+        If True, also return variance columns (``*_VARIANCE``) alongside the
+        standard errors (``*_SE``, always returned). Variance = SE squared.
     totals : bool, default True
         If True, include total area estimates expanded to population level.
         If False, only return per-acre values.
@@ -695,8 +696,10 @@ def area(
             Total area in acres, expanded to the population
         - **AREA_SE** : float
             Standard error of AREA (the total, in acres)
-        - **AREA_VARIANCE** : float
+        - **AREA_VARIANCE** : float (if variance=True)
             Variance of the total area in acres (equals AREA_SE squared)
+        - **AREA_VARIANCE_PERCENT** : float (if variance=True)
+            Variance of the percentage (equals AREA_SE_PERCENT squared)
         - **TOTAL_EXPNS** : float
             Total expansion factor (population acres) for the evaluation
         - **N_PLOTS** : int

--- a/src/pyfia/estimation/estimators/biomass.py
+++ b/src/pyfia/estimation/estimators/biomass.py
@@ -348,8 +348,8 @@ def biomass(
         - 'gs': Growing stock trees (live, merchantable, STATUSCD == 1 with
           specific quality requirements)
         - 'all': All trees regardless of status
-    component : str, default 'AG'
-        Biomass component to estimate. Valid options include:
+    component : {'AG', 'BG', 'TOTAL', 'BOLE', 'BRANCH', 'FOLIAGE'}, default 'AG'
+        Biomass component to estimate (case-insensitive):
 
         - 'AG': Aboveground biomass (stem, bark, branches, foliage)
         - 'BG': Belowground biomass (coarse roots)
@@ -357,13 +357,10 @@ def biomass(
         - 'BOLE': Main stem wood and bark
         - 'BRANCH': Live and dead branches
         - 'FOLIAGE': Leaves/needles
-        - 'ROOTS': Coarse roots (same as BG)
-        - 'STUMP': Stump biomass
-        - 'SAPLING': Sapling biomass
-        - 'TOP': Top and branches above merchantable height
 
-        Note: Not all components may be available for all species or regions.
-        Check TREE table for available DRYBIO_* columns.
+        For belowground/coarse-root biomass use 'BG'. Each value maps to a
+        DRYBIO_* column in the TREE table; values without a corresponding
+        column (e.g. 'ROOT', 'STUMP', 'TOP') are not supported.
     tree_domain : str, optional
         SQL-like filter expression for tree-level filtering. Applied to
         TREE table. Example: "DIA >= 10.0 AND SPCD == 131".
@@ -374,7 +371,8 @@ def biomass(
         If True, include population-level total estimates in addition to
         per-acre values. Totals are expanded using FIA expansion factors.
     variance : bool, default False
-        If True, calculate and include variance and standard error estimates.
+        If True, also return variance columns (``*_VARIANCE``) alongside the
+        standard errors (``*_SE``, always returned). Variance = SE squared.
         Note: Currently uses simplified variance calculation (10% of estimate).
     most_recent : bool, default False
         If True, automatically filter to the most recent evaluation for
@@ -393,14 +391,16 @@ def biomass(
             Carbon per acre in tons (47% of biomass)
         - **CARB_TOTAL** : float (if totals=True)
             Total carbon in tons expanded to population level
-        - **BIO_ACRE_SE** : float (if variance=True)
+        - **BIO_ACRE_SE** : float
             Standard error of per-acre biomass estimate
-        - **BIO_TOTAL_SE** : float (if variance=True and totals=True)
+        - **BIO_TOTAL_SE** : float (if totals=True)
             Standard error of total biomass estimate
-        - **CARB_ACRE_SE** : float (if variance=True)
+        - **CARB_ACRE_SE** : float
             Standard error of per-acre carbon estimate
-        - **CARB_TOTAL_SE** : float (if variance=True and totals=True)
+        - **CARB_TOTAL_SE** : float (if totals=True)
             Standard error of total carbon estimate
+        - **BIO_ACRE_VARIANCE**, **BIO_TOTAL_VARIANCE**, **CARB_ACRE_VARIANCE**, **CARB_TOTAL_VARIANCE** : float (if variance=True)
+            Variance of the corresponding estimate (= the matching _SE squared)
         - **AREA_TOTAL** : float
             Total area (acres) represented by the estimation
         - **N_PLOTS** : int

--- a/src/pyfia/estimation/estimators/growth.py
+++ b/src/pyfia/estimation/estimators/growth.py
@@ -558,8 +558,12 @@ def growth(
         - "market": Timber market categories (Pulpwood, Chip-n-Saw, Sawtimber)
     land_type : {'forest', 'timber'}, default 'forest'
         Land type to include in estimation.
-    tree_type : {'all', 'dead', 'gs', 'live'}, default 'gs'
-        Tree type to include.
+    tree_type : {'gs', 'al', 'sl', 'live', 'sawtimber'}, default 'gs'
+        Tree population to include (GRM tables):
+
+        - 'gs': growing stock
+        - 'al' or 'live': all live trees
+        - 'sl' or 'sawtimber': sawtimber-size trees
     measure : {'volume', 'biomass', 'count'}, default 'volume'
         What to measure in the growth estimation.
     tree_domain : str, optional
@@ -569,7 +573,8 @@ def growth(
     totals : bool, default True
         If True, include population-level total estimates.
     variance : bool, default False
-        If True, calculate and include variance and standard error estimates.
+        If True, also return variance columns (``*_VARIANCE``) alongside the
+        standard errors (``*_SE``, always returned). Variance = SE squared.
     most_recent : bool, default False
         If True, automatically filter to the most recent evaluation.
 
@@ -579,7 +584,10 @@ def growth(
         Growth estimates with columns:
         - GROWTH_ACRE: Annual growth per acre
         - GROWTH_TOTAL: Total annual growth (if totals=True)
-        - GROWTH_ACRE_SE: Standard error of per-acre estimate (if variance=True)
+        - GROWTH_ACRE_SE: Standard error of per-acre estimate
+        - GROWTH_TOTAL_SE: Standard error of total estimate (if totals=True)
+        - GROWTH_ACRE_VARIANCE, GROWTH_TOTAL_VARIANCE: Variance of the estimates,
+          equal to the matching _SE squared (if variance=True)
         - Additional grouping columns if specified
 
     See Also
@@ -609,11 +617,11 @@ def growth(
         validate_grp_by,
         validate_land_type,
         validate_mortality_measure,
-        validate_tree_type,
+        validate_tree_type_grm,
     )
 
     land_type = validate_land_type(land_type)
-    tree_type = validate_tree_type(tree_type)
+    tree_type = validate_tree_type_grm(tree_type)
     measure = validate_mortality_measure(measure)
     grp_by = validate_grp_by(grp_by)
     tree_domain = validate_domain_expression(tree_domain, "tree_domain")

--- a/src/pyfia/estimation/estimators/mortality.py
+++ b/src/pyfia/estimation/estimators/mortality.py
@@ -299,8 +299,12 @@ def mortality(
         - "market": Timber market categories (Pre-merchantable, Pulpwood, Chip-n-Saw, Sawtimber)
     land_type : {'forest', 'timber'}, default 'timber'
         Land type to include in estimation.
-    tree_type : {'all', 'dead', 'gs', 'live'}, default 'gs'
-        Tree type to include.
+    tree_type : {'gs', 'al', 'sl', 'live', 'sawtimber'}, default 'gs'
+        Tree population to include (GRM tables):
+
+        - 'gs': growing stock
+        - 'al' or 'live': all live trees
+        - 'sl' or 'sawtimber': sawtimber-size trees
     measure : {'volume', 'sawlog', 'biomass', 'tpa', 'count', 'basal_area'}, default 'volume'
         What to measure in the mortality estimation.
     tree_domain : str, optional
@@ -312,7 +316,8 @@ def mortality(
     totals : bool, default True
         If True, include population-level total estimates.
     variance : bool, default False
-        If True, calculate and include variance and standard error estimates.
+        If True, also return variance columns (``*_VARIANCE``) alongside the
+        standard errors (``*_SE``, always returned). Variance = SE squared.
     most_recent : bool, default False
         If True, automatically filter to the most recent evaluation.
 
@@ -322,8 +327,10 @@ def mortality(
         Mortality estimates with columns:
         - MORT_ACRE: Annual mortality per acre
         - MORT_TOTAL: Total annual mortality (if totals=True)
-        - MORT_ACRE_SE: Standard error of per-acre estimate (if variance=True)
-        - MORT_TOTAL_SE: Standard error of total estimate (if variance=True)
+        - MORT_ACRE_SE: Standard error of per-acre estimate
+        - MORT_TOTAL_SE: Standard error of total estimate (if totals=True)
+        - MORT_ACRE_VARIANCE, MORT_TOTAL_VARIANCE: Variance of the estimates,
+          equal to the matching _SE squared (if variance=True)
         - Additional grouping columns if specified
 
     See Also
@@ -376,11 +383,11 @@ def mortality(
         validate_grp_by,
         validate_land_type,
         validate_mortality_measure,
-        validate_tree_type,
+        validate_tree_type_grm,
     )
 
     land_type = validate_land_type(land_type)
-    tree_type = validate_tree_type(tree_type)
+    tree_type = validate_tree_type_grm(tree_type)
     measure = validate_mortality_measure(measure)
     grp_by = validate_grp_by(grp_by)
     tree_domain = validate_domain_expression(tree_domain, "tree_domain")

--- a/src/pyfia/estimation/estimators/removals.py
+++ b/src/pyfia/estimation/estimators/removals.py
@@ -232,8 +232,9 @@ def removals(
         - "market": Timber market categories (Pulpwood, Chip-n-Saw, Sawtimber)
     land_type : str
         Land type: "forest", "timber", or "all"
-    tree_type : str
-        Tree type: "gs" (growing stock), "all"
+    tree_type : {'gs', 'al', 'sl', 'live', 'sawtimber'}, default 'gs'
+        Tree population to include (GRM tables): 'gs' (growing stock),
+        'al'/'live' (all live), 'sl'/'sawtimber' (sawtimber-size).
     measure : str
         What to measure: "volume", "biomass", or "count"
     tree_domain : str | None
@@ -297,11 +298,11 @@ def removals(
         validate_land_type,
         validate_mortality_measure,
         validate_positive_number,
-        validate_tree_type,
+        validate_tree_type_grm,
     )
 
     land_type = validate_land_type(land_type)
-    tree_type = validate_tree_type(tree_type)
+    tree_type = validate_tree_type_grm(tree_type)
     measure = validate_mortality_measure(measure)
     grp_by = validate_grp_by(grp_by)
     tree_domain = validate_domain_expression(tree_domain, "tree_domain")

--- a/src/pyfia/estimation/estimators/tpa.py
+++ b/src/pyfia/estimation/estimators/tpa.py
@@ -237,24 +237,9 @@ class TPAEstimator(BaseEstimator):
 
         results = self._calculate_variance_for_metrics(agg_result, metric_configs)
 
-        # Convert to variance if requested (swap SE columns for VAR columns)
-        if self.config.get("variance", False):
-            results = results.with_columns(
-                [
-                    (pl.col("TPA_SE") ** 2).alias("TPA_VAR"),
-                    (pl.col("BAA_SE") ** 2).alias("BAA_VAR"),
-                ]
-            )
-            results = results.drop(["TPA_SE", "BAA_SE"])
-
-            if "TPA_TOTAL_SE" in results.columns:
-                results = results.with_columns(
-                    [
-                        (pl.col("TPA_TOTAL_SE") ** 2).alias("TPA_TOTAL_VAR"),
-                        (pl.col("BAA_TOTAL_SE") ** 2).alias("BAA_TOTAL_VAR"),
-                    ]
-                )
-                results = results.drop(["TPA_TOTAL_SE", "BAA_TOTAL_SE"])
+        # Standard errors are always retained. Variance columns (if requested
+        # via variance=True) are added uniformly by apply_variance_columns at
+        # the end of the pipeline, so we no longer swap/drop SE columns here.
 
         # Add warning for small sample sizes
         if "N_PLOTS" in results.columns:
@@ -314,24 +299,17 @@ class TPAEstimator(BaseEstimator):
         # Add per-acre estimate columns
         col_order.extend(["TPA", "BAA"])
 
-        # Add uncertainty columns (SE or VAR based on config)
-        if self.config.get("variance", False):
-            if "TPA_VAR" in results.columns:
-                col_order.extend(["TPA_VAR", "BAA_VAR"])
-        else:
-            if "TPA_SE" in results.columns:
-                col_order.extend(["TPA_SE", "BAA_SE"])
+        # Add uncertainty columns (standard errors). Variance columns, if
+        # requested, are appended uniformly by apply_variance_columns.
+        if "TPA_SE" in results.columns:
+            col_order.extend(["TPA_SE", "BAA_SE"])
 
         # Add total columns if present
         if self.config.get("totals", False):
             if "TPA_TOTAL" in results.columns:
                 col_order.extend(["TPA_TOTAL", "BAA_TOTAL"])
-                if self.config.get("variance", False):
-                    if "TPA_TOTAL_VAR" in results.columns:
-                        col_order.extend(["TPA_TOTAL_VAR", "BAA_TOTAL_VAR"])
-                else:
-                    if "TPA_TOTAL_SE" in results.columns:
-                        col_order.extend(["TPA_TOTAL_SE", "BAA_TOTAL_SE"])
+                if "TPA_TOTAL_SE" in results.columns:
+                    col_order.extend(["TPA_TOTAL_SE", "BAA_TOTAL_SE"])
 
         # Add CV columns if present
         if self.config.get("include_cv", False):
@@ -459,8 +437,9 @@ def tpa(
         in addition to per-acre values. Total estimates are expanded using
         stratification factors.
     variance : bool, default False
-        If True, return variance instead of standard error. Standard error
-        is calculated as the square root of variance.
+        If True, also return variance columns (``*_VARIANCE``) alongside the
+        standard errors. Standard errors (``*_SE``) are always returned;
+        variance equals the standard error squared.
 
     Returns
     -------
@@ -475,22 +454,22 @@ def tpa(
             Trees per acre
         - **BAA** : float
             Basal area per acre (square feet)
-        - **TPA_SE** : float (if variance=False)
+        - **TPA_SE** : float
             Standard error of TPA estimate
-        - **BAA_SE** : float (if variance=False)
+        - **BAA_SE** : float
             Standard error of BAA estimate
-        - **TPA_VAR** : float (if variance=True)
-            Variance of TPA estimate
-        - **BAA_VAR** : float (if variance=True)
-            Variance of BAA estimate
+        - **TPA_VARIANCE**, **BAA_VARIANCE** : float (if variance=True)
+            Variance of the per-acre estimates (= the SE columns squared)
         - **TPA_TOTAL** : float (if totals=True)
             Total trees expanded to population level
         - **BAA_TOTAL** : float (if totals=True)
             Total basal area expanded to population level
-        - **TPA_TOTAL_SE** : float (if totals=True and variance=False)
+        - **TPA_TOTAL_SE** : float (if totals=True)
             Standard error of total TPA
-        - **BAA_TOTAL_SE** : float (if totals=True and variance=False)
+        - **BAA_TOTAL_SE** : float (if totals=True)
             Standard error of total BAA
+        - **TPA_TOTAL_VARIANCE**, **BAA_TOTAL_VARIANCE** : float (if totals=True and variance=True)
+            Variance of the totals (= the total SE columns squared)
         - **N_PLOTS** : int
             Number of FIA plots in estimate
         - **N_TREES** : int

--- a/src/pyfia/estimation/estimators/volume.py
+++ b/src/pyfia/estimation/estimators/volume.py
@@ -418,7 +418,8 @@ def volume(
         If True, include total volume estimates expanded to population level.
         If False, only return per-acre values.
     variance : bool, default False
-        If True, return variance instead of standard error.
+        If True, also return variance columns (``*_VARIANCE``) alongside the
+        standard errors (``*_SE``, always returned). Variance = SE squared.
     most_recent : bool, default False
         If True, automatically select the most recent evaluation for each
         state/region. Equivalent to calling db.clip_most_recent() first.
@@ -444,10 +445,10 @@ def volume(
             Sound cubic foot volume per acre
         - **VOLBFNET_ACRE** : float (if vol_type='sawlog')
             Net board foot volume per acre
-        - **VOLCFNET_ACRE_SE** : float (if variance=False)
+        - **VOLCFNET_ACRE_SE** : float
             Standard error of per-acre volume estimate
-        - **VOLCFNET_ACRE_VAR** : float (if variance=True)
-            Variance of per-acre volume estimate
+        - **VOLCFNET_ACRE_VARIANCE** : float (if variance=True)
+            Variance of per-acre volume estimate (= VOLCFNET_ACRE_SE squared)
         - **N_PLOTS** : int
             Number of plots in estimate
         - **N_TREES** : int
@@ -456,8 +457,10 @@ def volume(
             Total area (acres) represented by the estimation
         - **VOLCFNET_TOTAL** : float (if totals=True)
             Total volume expanded to population level
-        - **VOLCFNET_TOTAL_SE** : float (if totals=True and variance=False)
+        - **VOLCFNET_TOTAL_SE** : float (if totals=True)
             Standard error of total volume
+        - **VOLCFNET_TOTAL_VARIANCE** : float (if totals=True and variance=True)
+            Variance of total volume (= VOLCFNET_TOTAL_SE squared)
 
     See Also
     --------

--- a/src/pyfia/estimation/utils.py
+++ b/src/pyfia/estimation/utils.py
@@ -349,6 +349,50 @@ def _enhance_grouping_columns(df: pl.DataFrame) -> pl.DataFrame:
     return df
 
 
+def apply_variance_columns(df: pl.DataFrame, variance: bool) -> pl.DataFrame:
+    """Apply pyFIA's standard-error / variance output contract.
+
+    pyFIA always reports standard errors (``*_SE`` columns). Variance columns
+    are opt-in: when ``variance=True`` every standard-error column gets a
+    matching ``*_VARIANCE`` column equal to the standard error squared
+    (e.g. ``VOLCFNET_TOTAL_SE`` -> ``VOLCFNET_TOTAL_VARIANCE``,
+    ``AREA_SE_PERCENT`` -> ``AREA_VARIANCE_PERCENT``). Standard-error columns
+    are never removed.
+
+    This is applied once, at the end of the estimation pipeline, so the
+    contract is uniform across every estimator regardless of how each one
+    formats its own output.
+
+    Parameters
+    ----------
+    df : pl.DataFrame
+        Formatted estimator output.
+    variance : bool
+        If True, add ``*_VARIANCE`` columns alongside the ``*_SE`` columns.
+
+    Returns
+    -------
+    pl.DataFrame
+        Output with variance columns added (variance=True) or with any
+        pre-existing variance columns removed (variance=False).
+    """
+    # Drop any pre-existing variance columns so the naming/contract is uniform
+    # regardless of what individual estimators compute internally.
+    preexisting = [c for c in df.columns if "_VARIANCE" in c]
+    if preexisting:
+        df = df.drop(preexisting)
+
+    if not variance:
+        return df
+
+    se_cols = [c for c in df.columns if c.endswith("_SE") or c.endswith("_SE_PERCENT")]
+    if se_cols:
+        df = df.with_columns(
+            [(pl.col(c) ** 2).alias(c.replace("_SE", "_VARIANCE")) for c in se_cols]
+        )
+    return df
+
+
 def format_output_columns(
     df: pl.DataFrame,
     estimation_type: str,

--- a/src/pyfia/validation.py
+++ b/src/pyfia/validation.py
@@ -10,7 +10,10 @@ from typing import Any
 VALID_LAND_TYPES = {"forest", "timber", "all"}
 VALID_TREE_TYPES = {"live", "dead", "gs", "all"}
 VALID_VOL_TYPES = {"net", "gross", "sound", "sawlog"}
-VALID_BIOMASS_COMPONENTS = {"total", "ag", "bg", "bole", "branch", "foliage", "root"}
+# NOTE: keep in sync with BiomassEstimator.get_tree_columns(); each non-AG/BG/TOTAL
+# value must map to an existing DRYBIO_<COMPONENT> column in the TREE table.
+# Belowground/coarse-root biomass is "bg" (DRYBIO_BG); there is no DRYBIO_ROOT.
+VALID_BIOMASS_COMPONENTS = {"total", "ag", "bg", "bole", "branch", "foliage"}
 VALID_TEMPORAL_METHODS = {"TI", "ANNUAL", "SMA", "LMA", "EMA"}
 
 
@@ -30,6 +33,25 @@ def validate_tree_type(tree_type: str) -> str:
         raise ValueError(
             f"Invalid tree_type '{tree_type}'. "
             f"Must be one of: {', '.join(sorted(VALID_TREE_TYPES))}"
+        )
+    return tree_type
+
+
+# GRM estimators (growth / mortality / removals) accept a wider tree-type
+# vocabulary than the area/volume/biomass/tpa estimators: the GRM tables carry
+# growing-stock (GS), all-live (AL), and sawlog/sawtimber (SL) population
+# columns. 'live' is an alias for 'al' and 'sawtimber' for 'sl'. See
+# grm.normalize_tree_type / grm.resolve_grm_columns. Note 'all'/'dead' are NOT
+# valid here — they would silently fall through to growing stock.
+VALID_TREE_TYPES_GRM = {"gs", "al", "sl", "live", "sawtimber"}
+
+
+def validate_tree_type_grm(tree_type: str) -> str:
+    """Validate tree_type for GRM estimators (growth/mortality/removals)."""
+    if tree_type not in VALID_TREE_TYPES_GRM:
+        raise ValueError(
+            f"Invalid tree_type '{tree_type}'. "
+            f"Must be one of: {', '.join(sorted(VALID_TREE_TYPES_GRM))}"
         )
     return tree_type
 

--- a/tests/integration/test_estimator_bugs_109_110_111.py
+++ b/tests/integration/test_estimator_bugs_109_110_111.py
@@ -1,0 +1,118 @@
+"""Regression tests for the 1.4.2 estimator bug fixes (#109, #110, #111).
+
+These run against the real Georgia FIA database and skip automatically when no
+local database is available (e.g. in CI). The CI-safe guards live in
+tests/unit/test_validation.py and tests/unit/test_variance_columns.py.
+"""
+
+import pytest
+
+from pyfia import FIA, biomass, growth, mortality, removals, tpa, volume
+
+pytestmark = [pytest.mark.integration, pytest.mark.db]
+
+GA_FIPS = 13
+
+
+@pytest.fixture
+def ga_path(georgia_db_path):
+    return georgia_db_path if isinstance(georgia_db_path, str) else str(georgia_db_path)
+
+
+def _clip(path, token):
+    db = FIA(path)
+    db.clip_by_state(GA_FIPS)
+    db.clip_most_recent(eval_type=token)
+    return db
+
+
+class TestBiomassComponents:
+    """#110: every advertised component works; 'root' is rejected cleanly."""
+
+    @pytest.mark.parametrize(
+        "component", ["AG", "BG", "TOTAL", "BOLE", "BRANCH", "FOLIAGE"]
+    )
+    def test_valid_component_runs(self, ga_path, component):
+        db = _clip(ga_path, "VOL")
+        result = biomass(db, component=component, land_type="forest")
+        assert "BIO_ACRE" in result.columns
+        assert len(result) > 0
+
+    def test_root_component_rejected(self, ga_path):
+        db = _clip(ga_path, "VOL")
+        with pytest.raises(ValueError, match="Invalid biomass component"):
+            biomass(db, component="ROOT")
+
+
+class TestVarianceContract:
+    """#109: SE always present; *_VARIANCE added iff variance=True; variance==SE**2."""
+
+    @pytest.mark.parametrize(
+        "fn,token,kwargs",
+        [
+            (volume, "VOL", {}),
+            (biomass, "VOL", {"component": "AG"}),
+            (tpa, "VOL", {}),
+            (mortality, "MORT", {"measure": "volume"}),
+        ],
+        ids=["volume", "biomass", "tpa", "mortality"],
+    )
+    def test_variance_flag_is_additive(self, ga_path, fn, token, kwargs):
+        db = _clip(ga_path, token)
+        off = fn(db, totals=True, variance=False, **kwargs)
+        on = fn(db, totals=True, variance=True, **kwargs)
+
+        se_cols = [c for c in off.columns if c.endswith("_SE")]
+        assert se_cols, "estimator must always report standard errors"
+
+        # Default: no variance columns.
+        assert not [c for c in off.columns if "_VARIANCE" in c]
+
+        # variance=True: SE columns retained AND matching variance columns added.
+        for se in se_cols:
+            assert se in on.columns
+            var = se.replace("_SE", "_VARIANCE")
+            assert var in on.columns
+            if on[se][0] is not None:
+                assert on[var][0] == pytest.approx(on[se][0] ** 2, rel=1e-9)
+
+
+class TestGRMTreeType:
+    """#111: GRM estimators accept gs/al/sl/live/sawtimber with the right aliasing."""
+
+    @pytest.mark.parametrize(
+        "fn,token", [(mortality, "MORT"), (growth, "GROW"), (removals, "REMV")]
+    )
+    def test_grm_tree_type_vocabulary(self, ga_path, fn, token):
+        db = _clip(ga_path, token)
+
+        def total(tree_type):
+            r = fn(db, measure="volume", land_type="forest", tree_type=tree_type)
+            tcol = next(c for c in r.columns if c.endswith("_TOTAL"))
+            return r[tcol][0]
+
+        gs, al, sl, live, saw = (
+            total("gs"),
+            total("al"),
+            total("sl"),
+            total("live"),
+            total("sawtimber"),
+        )
+
+        # All produce real estimates.
+        for v in (gs, al, sl):
+            assert v is not None and v > 0
+
+        # Aliases: live == al, sawtimber == sl.
+        assert live == pytest.approx(al, rel=1e-9)
+        assert saw == pytest.approx(sl, rel=1e-9)
+
+        # The three populations are distinct (all-live > growing stock > sawtimber).
+        assert al > gs > sl
+
+    @pytest.mark.parametrize("fn", [mortality, growth, removals])
+    def test_grm_rejects_non_grm_tree_types(self, ga_path, fn):
+        db = _clip(ga_path, "MORT")
+        for bad in ("all", "dead"):
+            with pytest.raises(ValueError, match="Invalid tree_type"):
+                fn(db, measure="volume", tree_type=bad)

--- a/tests/integration/test_grm_cond_columns.py
+++ b/tests/integration/test_grm_cond_columns.py
@@ -18,9 +18,9 @@ GA_FIPS = 13
 
 # (function, eval_type token, estimator-specific kwargs)
 GRM_SPECS = [
-    (growth, "GROW", dict(measure="biomass", tree_type="all")),
-    (mortality, "MORT", dict(measure="biomass", tree_type="all")),
-    (removals, "REMV", dict(measure="biomass", tree_type="all")),
+    (growth, "GROW", dict(measure="biomass", tree_type="al")),
+    (mortality, "MORT", dict(measure="biomass", tree_type="al")),
+    (removals, "REMV", dict(measure="biomass", tree_type="al")),
     (biomass, "VOL", dict(component="AG", tree_type="live")),
 ]
 

--- a/tests/integration/test_spatial.py
+++ b/tests/integration/test_spatial.py
@@ -260,8 +260,10 @@ class TestSpatialWithEstimators:
             result = tpa(db, grp_by=["REGION"], tree_type="live", variance=True)
 
             assert result is not None
-            # Should have variance columns (TPA_VAR contains variance for TPA)
-            assert "TPA_VAR" in result.columns or "TPA_SE" in result.columns
+            # variance=True keeps the standard errors and adds matching
+            # *_VARIANCE columns (variance = SE squared).
+            assert "TPA_SE" in result.columns
+            assert "TPA_VARIANCE" in result.columns
 
     def test_north_south_region_assignment(self, db_path, north_south_regions):
         """Test that plots are correctly assigned to North/South regions."""

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -14,6 +14,7 @@ from pyfia.validation import (
     validate_sql_identifier,
     validate_temporal_method,
     validate_tree_type,
+    validate_tree_type_grm,
     validate_vol_type,
 )
 
@@ -47,6 +48,23 @@ class TestValidators:
         with pytest.raises(ValueError, match="Invalid tree_type"):
             validate_tree_type("growing_stock")
 
+    def test_validate_tree_type_rejects_grm_only_values(self):
+        """#111: al/sl/sawtimber are GRM-only; the base validator rejects them."""
+        for value in ("al", "sl", "sawtimber"):
+            with pytest.raises(ValueError, match="Invalid tree_type"):
+                validate_tree_type(value)
+
+    def test_validate_tree_type_grm_valid(self):
+        """#111: GRM estimators accept the wider tree-type vocabulary."""
+        for value in ("gs", "al", "sl", "live", "sawtimber"):
+            assert validate_tree_type_grm(value) == value
+
+    def test_validate_tree_type_grm_invalid(self):
+        """#111: GRM validator rejects all/dead (they would silently map to GS)."""
+        for value in ("all", "dead", "growing_stock"):
+            with pytest.raises(ValueError, match="Invalid tree_type"):
+                validate_tree_type_grm(value)
+
     def test_validate_vol_type_valid(self):
         """Test valid volume type values."""
         assert validate_vol_type("net") == "net"
@@ -70,6 +88,16 @@ class TestValidators:
         """Test invalid biomass component values."""
         with pytest.raises(ValueError, match="Invalid biomass component"):
             validate_biomass_component("invalid")
+
+    def test_validate_biomass_component_rejects_root(self):
+        """#110: 'root' is not a valid component (no DRYBIO_ROOT; use 'bg')."""
+        with pytest.raises(ValueError, match="Invalid biomass component"):
+            validate_biomass_component("root")
+
+    def test_validate_biomass_component_supported_set(self):
+        """#110: every advertised component validates (lowercased input)."""
+        for value in ("ag", "bg", "total", "bole", "branch", "foliage"):
+            assert validate_biomass_component(value) == value
 
     def test_validate_mortality_measure_valid(self):
         """Test valid mortality measure values."""

--- a/tests/unit/test_variance_columns.py
+++ b/tests/unit/test_variance_columns.py
@@ -1,0 +1,76 @@
+"""CI-safe unit tests for the variance-column output contract (#109).
+
+pyFIA always reports standard errors (``*_SE``). Variance columns are opt-in
+via ``variance=True``, added as ``*_VARIANCE = (*_SE) ** 2`` without ever
+dropping the standard-error columns. This is enforced centrally by
+``apply_variance_columns`` so the contract is uniform across every estimator.
+"""
+
+import polars as pl
+import pytest
+
+from pyfia.estimation.utils import apply_variance_columns
+
+
+@pytest.fixture
+def sample() -> pl.DataFrame:
+    """Mimic a formatted estimator output (per-acre + total estimates + SE)."""
+    return pl.DataFrame(
+        {
+            "YEAR": [2023],
+            "VOLCFNET_ACRE": [100.0],
+            "VOLCFNET_TOTAL": [1_000_000.0],
+            "VOLCFNET_ACRE_SE": [3.0],
+            "VOLCFNET_TOTAL_SE": [50_000.0],
+            "N_PLOTS": [42],
+        }
+    )
+
+
+class TestApplyVarianceColumns:
+    def test_default_is_standard_errors_only(self, sample):
+        """variance=False: SE columns kept, no variance columns added."""
+        out = apply_variance_columns(sample, variance=False)
+        assert "VOLCFNET_TOTAL_SE" in out.columns
+        assert not [c for c in out.columns if "_VARIANCE" in c]
+
+    def test_variance_true_adds_variance_keeps_se(self, sample):
+        """variance=True: adds *_VARIANCE = SE**2 and keeps every *_SE column."""
+        out = apply_variance_columns(sample, variance=True)
+        # SE columns are never removed.
+        assert "VOLCFNET_ACRE_SE" in out.columns
+        assert "VOLCFNET_TOTAL_SE" in out.columns
+        # Matching variance columns are added with SE-mirrored names.
+        assert out["VOLCFNET_ACRE_VARIANCE"][0] == pytest.approx(3.0**2)
+        assert out["VOLCFNET_TOTAL_VARIANCE"][0] == pytest.approx(50_000.0**2)
+        # Non-uncertainty columns are untouched.
+        assert out["VOLCFNET_TOTAL"][0] == 1_000_000.0
+        assert out["N_PLOTS"][0] == 42
+
+    def test_percentage_se_naming(self):
+        """AREA_SE_PERCENT -> AREA_VARIANCE_PERCENT (the '_SE' token is replaced)."""
+        df = pl.DataFrame({"AREA_SE": [10.0], "AREA_SE_PERCENT": [0.5]})
+        out = apply_variance_columns(df, variance=True)
+        assert out["AREA_VARIANCE"][0] == pytest.approx(100.0)
+        assert out["AREA_VARIANCE_PERCENT"][0] == pytest.approx(0.25)
+
+    def test_preexisting_variance_dropped_when_off(self):
+        """Inconsistent pre-existing variance columns are removed when off."""
+        df = pl.DataFrame({"VOLCFNET_TOTAL_SE": [5.0], "VOLUME_TOTAL_VARIANCE": [99.0]})
+        out = apply_variance_columns(df, variance=False)
+        assert "VOLUME_TOTAL_VARIANCE" not in out.columns
+        assert "VOLCFNET_TOTAL_SE" in out.columns
+
+    def test_preexisting_variance_renamed_when_on(self):
+        """Pre-existing variance columns are replaced by SE-derived ones."""
+        df = pl.DataFrame({"VOLCFNET_TOTAL_SE": [5.0], "VOLUME_TOTAL_VARIANCE": [99.0]})
+        out = apply_variance_columns(df, variance=True)
+        # Old inconsistent name gone; SE-mirrored name present and correct.
+        assert "VOLUME_TOTAL_VARIANCE" not in out.columns
+        assert out["VOLCFNET_TOTAL_VARIANCE"][0] == pytest.approx(25.0)
+
+    def test_no_se_columns_is_noop(self):
+        """A frame with no SE columns is returned unchanged when variance=True."""
+        df = pl.DataFrame({"YEAR": [2023], "TPA": [150.0]})
+        out = apply_variance_columns(df, variance=True)
+        assert out.columns == ["YEAR", "TPA"]

--- a/uv.lock
+++ b/uv.lock
@@ -872,7 +872,7 @@ wheels = [
 
 [[package]]
 name = "pyfia"
-version = "1.4.1"
+version = "1.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "connectorx" },


### PR DESCRIPTION
## Summary

Bug-fix release (**1.4.2**) closing the three code issues found in the v1.4.1 docs audit. **Point estimates and standard errors are unchanged** for every previously-working query — the changes are to input validation and the opt-in variance columns only. Verified against the Georgia FIA DB; `pytest tests/unit`, `mypy src/pyfia/`, and `ruff check src/pyfia/` are clean.

## Fixes

### #110 — `biomass(component="ROOT")` crashed (`BinderException`)
`"root"` passed validation then selected a non-existent `DRYBIO_ROOT` column. Removed `"root"` from the valid set (use `"bg"` for belowground/coarse-root biomass — `DRYBIO_BG`). Valid components: `AG, BG, TOTAL, BOLE, BRANCH, FOLIAGE` (case-insensitive). Cleaned the biomass docstring (it had also advertised the bogus `ROOTS/STUMP/SAPLING/TOP`).

### #111 — GRM estimators rejected the `tree_type` values they support
`growth()`/`mortality()`/`removals()` advertise and internally handle `gs`/`al`/`sl`/`live`/`sawtimber` (the GRM tables carry GS/AL/SL population columns), but the shared validator only allowed `{all, dead, gs, live}` → `ValueError`. Added `validate_tree_type_grm` accepting `{gs, al, sl, live, sawtimber}` for the GRM estimators; `area`/`volume`/`biomass`/`tpa` keep `{all, dead, gs, live}`. Verified on Georgia: `al==live`, `sl==sawtimber`, and `al > gs > sl` as expected.

**Behavior change:** GRM estimators no longer silently accept `tree_type="all"`/`"dead"` (they previously fell through to growing stock) — they now raise a clear `ValueError`.

### #109 — `variance=True` was a no-op (and dropped SE for `tpa`)
The flag did nothing for most estimators, and for `tpa()` it *dropped* the standard-error columns. Now: **`*_SE` columns are always returned**, and `variance=True` adds matching **`*_VARIANCE`** columns (= SE²) uniformly across every estimator, via a single `apply_variance_columns` step in `BaseEstimator.estimate()`.

**Contract change:** `area()`/`volume()` no longer emit variance columns by default (opt in with `variance=True`). Variance columns use the SE-mirrored name (`VOLCFNET_TOTAL_SE` → `VOLCFNET_TOTAL_VARIANCE`, `AREA_SE_PERCENT` → `AREA_VARIANCE_PERCENT`); `tpa`'s old `*_VAR` columns are renamed `*_VARIANCE`.

## Tests
- CI-safe unit tests: GRM vs strict tree_type validators; biomass `root` rejection + supported set; `apply_variance_columns` contract.
- Georgia-backed integration tests (skip without a local DB) for all three issues.
- Updated existing GRM cond-column tests (valid GRM `tree_type`) and the spatial tpa test (new SE+VARIANCE contract).

## Docs
- `concepts/variance.mdx` + `getting-started.mdx` describe the fixed, uniform contract.
- Regenerated `docs/api/*.mdx` from the corrected docstrings (no NSVB carbon leak; 17 pages).

## Verification
- `pytest tests/unit` → 768 passed. Full suite: 831 passed, 1 failed (`test_intersect_polygons_with_area_grp_by` — pre-existing on `main`, unrelated spatial+REGION path).
- SE/point-estimate values bit-identical with/without `variance=True` (confirmed; remaining diffs are last-ULP FP noise present regardless of the flag).

Closes #109. Closes #110. Closes #111.
