### PR TITLE
chore: fix pre-existing ruff lint + formatting drift

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ select = ["E", "F", "I", "N", "W"]
 ignore = [
     "E501",  # line too long
     "N803",  # argument name should be lowercase (keeping R/FIA conventions)
+    "N806",  # variable in function should be lowercase (statistical notation: A, W_h, ...)
     "N815",  # mixed case variable in class scope (keeping R/FIA conventions)
     "E722",  # bare except
     "E402",  # module import not at top

--- a/src/pyfia/constants/defaults.py
+++ b/src/pyfia/constants/defaults.py
@@ -61,7 +61,6 @@ class ValidationRanges:
     MAX_PLOTS = 1_000_000
 
 
-
 class ErrorMessages:
     """Standard error messages."""
 

--- a/src/pyfia/estimation/estimators/area.py
+++ b/src/pyfia/estimation/estimators/area.py
@@ -365,15 +365,13 @@ class AreaEstimator(BaseEstimator):
         try:
             strat_data = self._get_stratification_data()
             strat_schema = strat_data.collect_schema().names()
-            select_cols = ["PLT_CN"] + [
-                c for c in strat_cols if c in strat_schema
-            ] + ["EXPNS"]
+            select_cols = (
+                ["PLT_CN"] + [c for c in strat_cols if c in strat_schema] + ["EXPNS"]
+            )
             all_plots = strat_data.select(select_cols).unique().collect()
         except (KeyError, AttributeError):
             # Fallback: derive all plots from the plot data itself
-            all_plots = plot_data.select(
-                ["PLT_CN"] + strat_cols + ["EXPNS"]
-            ).unique()
+            all_plots = plot_data.select(["PLT_CN"] + strat_cols + ["EXPNS"]).unique()
 
         # If we have grouping variables, calculate variance for each group
         if group_cols:
@@ -410,7 +408,9 @@ class AreaEstimator(BaseEstimator):
                         all_plots_group, strat_cols
                     )
                     # Calculate SE% from the area total in results
-                    area_col = "AREA_TOTAL" if "AREA_TOTAL" in results.columns else "AREA"
+                    area_col = (
+                        "AREA_TOTAL" if "AREA_TOTAL" in results.columns else "AREA"
+                    )
                     area_idx = results.columns.index(area_col)
                     area_total = group_vals[area_idx]
                     se_total = var_stats["se_total"]

--- a/src/pyfia/estimation/estimators/carbon_pools.py
+++ b/src/pyfia/estimation/estimators/carbon_pools.py
@@ -257,7 +257,11 @@ class CarbonPoolEstimator(BaseEstimator):
             plot_level_cols.insert(1, "STRATUM_CN")
         if group_cols:
             plot_level_cols.extend(
-                [c for c in group_cols if c in plot_cond_data.columns and c not in plot_level_cols]
+                [
+                    c
+                    for c in group_cols
+                    if c in plot_cond_data.columns and c not in plot_level_cols
+                ]
             )
 
         # Include CONDPROP_UNADJ for correct area proportion (x_i)

--- a/tests/unit/test_cache_integrity.py
+++ b/tests/unit/test_cache_integrity.py
@@ -86,7 +86,9 @@ class TestAtomicDownload:
         client = self._client()
         client.session.get.return_value = self._response([b"abc", b"def"])
         dest = tmp_path / "TREE.csv"
-        out = client._download_file("http://example/TREE.csv", dest, show_progress=False)
+        out = client._download_file(
+            "http://example/TREE.csv", dest, show_progress=False
+        )
         assert out == dest
         assert dest.read_bytes() == b"abcdef"
         assert not dest.with_name("TREE.csv.part").exists()

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -1,6 +1,5 @@
 """Tests for pyFIA constants and defaults."""
 
-
 from pyfia.constants.defaults import (
     Defaults,
     ErrorMessages,
@@ -79,7 +78,6 @@ class TestValidationRanges:
         assert ValidationRanges.MIN_PLOTS == 1
         assert ValidationRanges.MAX_PLOTS == 1_000_000
         assert ValidationRanges.MIN_PLOTS < ValidationRanges.MAX_PLOTS
-
 
 
 class TestErrorMessages:

--- a/tests/unit/test_volume_estimator.py
+++ b/tests/unit/test_volume_estimator.py
@@ -4,7 +4,6 @@ Tests the VolumeEstimator methods in isolation using mock data.
 No database connection required.
 """
 
-
 import polars as pl
 import pytest
 

--- a/tests/validation/test_all_snum.py
+++ b/tests/validation/test_all_snum.py
@@ -59,8 +59,6 @@ def get_all_snums_by_category():
         if cat not in categories:
             categories[cat] = []
         desc = SNUM_DESCRIPTIONS.get(e.value, "Unknown")
-        # Truncate description for test ID readability
-        short_desc = desc[:50] + "..." if len(desc) > 50 else desc
         categories[cat].append(
             pytest.param(
                 e.value,

--- a/tests/validation/test_area.py
+++ b/tests/validation/test_area.py
@@ -1,6 +1,5 @@
 """Area estimation validation against EVALIDator."""
 
-
 from pyfia import FIA, area
 from pyfia.evalidator.validation import compare_estimates
 

--- a/tests/validation/test_area_change.py
+++ b/tests/validation/test_area_change.py
@@ -26,7 +26,6 @@ References:
 - EVALIDator snum table: https://apps.fs.usda.gov/fiadb-api/fullreport/parameters/snum
 """
 
-
 from pyfia import FIA, area_change
 
 from .conftest import (

--- a/tests/validation/test_carbon_flux.py
+++ b/tests/validation/test_carbon_flux.py
@@ -109,7 +109,6 @@ class TestCarbonFluxValidation:
         growth_biomass = growth_result["GROWTH_TOTAL"][0]
         growth_carbon = flux_result["GROWTH_CARBON_TOTAL"][0]
 
-        expected_carbon = growth_biomass * CARBON_FRACTION
         actual_fraction = growth_carbon / growth_biomass if growth_biomass > 0 else 0
 
         print("\nCarbon Fraction Validation:")


### PR DESCRIPTION
Cleans up the two pre-existing lint/format issues flagged during the 1.4.2 work (independent of #114; both branch off `main`).

## `ruff format` drift
`ruff format --check` flagged 8 files with accumulated formatting drift (e.g. line-wrapping in `area.py`'s area-variance path). Ran `ruff format` over them — whitespace/line-wrapping only, **no behavior change**. `ruff format --check` is now clean repo-wide (124 files).

## `ruff check` errors (7)
- **5× N806** in `tests/unit/test_variance_formulas.py` — variance-formula tests use statistical notation (`A` = area, `W_h` = stratum weight) that mirrors Bechtold & Patterson. Added `N806` to the ignore list alongside the existing `N803`/`N815` "keeping R/FIA conventions" ignores.
- **2× F841** (genuinely unused locals) — removed `short_desc` (`test_all_snum.py`) and `expected_carbon` (`test_carbon_flux.py`; the carbon-fraction check already asserts on `actual_fraction`).

## Verification
`ruff check src/ tests/` ✓, `ruff format --check src/ tests/` ✓, `mypy src/pyfia/` ✓, full suite 803 passed.

> Note: the suite still shows 1 pre-existing failure, `test_intersect_polygons_with_area_grp_by` (a `REGION` column dropped on the spatial intersect + area `grp_by` path). That's a separate functional bug, not a lint/format issue, so it's out of scope here.