### PR TITLE
fix: spatial grp_by (#116) + area_change/mortality variance cleanups (1.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,19 +33,21 @@ live-tree-stock implementations (#89).
 
 ## [1.4.2] - 2026-06-30
 
-Bug-fix release closing three estimator issues found in the v1.4.1 public-docs
-audit (#109, #110, #111). Point estimates and standard errors are unchanged for
-every previously-working query; the changes concern input validation and the
-opt-in variance columns only.
+Bug-fix release closing four estimator issues found in the v1.4.1 public-docs
+audit and the follow-up review (#109, #110, #111, #116). Point estimates and
+standard errors are unchanged for every previously-working query; the changes
+concern input validation, spatial grouping, and the opt-in variance columns.
 
 ### Fixed
 - **`biomass(component="ROOT")` crashed with a `BinderException`** (#110) — `"root"` passed validation but then selected a non-existent `DRYBIO_ROOT` column. `"root"` has been removed from the valid component set; use `"bg"` for belowground/coarse-root biomass (`DRYBIO_BG`). Valid components are `AG`, `BG`, `TOTAL`, `BOLE`, `BRANCH`, `FOLIAGE` (case-insensitive).
+- **`area(grp_by=<intersect_polygons attribute>)` crashed with a `BinderException`** (#116) — a spatial attribute (e.g. `REGION`) added by `intersect_polygons()` was routed into the `COND` query, where it does not exist. `area()` no longer requests polygon attributes from `COND` (they are supplied by the plot/stratification join), so spatial grouping works.
 - **GRM estimators rejected the `tree_type` values they actually support** (#111) — `growth()`/`mortality()`/`removals()` advertise and internally handle `gs`/`al`/`sl`/`live`/`sawtimber`, but the shared validator only allowed `{all, dead, gs, live}`, so following the documented API raised `ValueError`. These estimators now validate against `{gs, al, sl, live, sawtimber}` (`al`/`live` → all-live, `sl`/`sawtimber` → sawtimber-size). `area()`/`volume()`/`biomass()`/`tpa()` keep `{all, dead, gs, live}`.
 - **`variance=True` did not add variance columns (and broke `tpa()`)** (#109) — the flag was a no-op for most estimators, and for `tpa()` it dropped the standard-error columns entirely. Standard errors (`*_SE`) are now always returned, and `variance=True` adds matching `*_VARIANCE` columns (equal to the standard error squared) uniformly across every estimator.
 
 ### Changed
-- **The standard-error / variance output contract is now uniform and opt-in.** `area()` and `volume()` no longer emit variance columns by default — pass `variance=True`. Variance columns use the standard-error-mirrored name (e.g. `VOLCFNET_TOTAL_SE` → `VOLCFNET_TOTAL_VARIANCE`, `AREA_SE_PERCENT` → `AREA_VARIANCE_PERCENT`); `tpa()`'s previous `*_VAR` columns are renamed to `*_VARIANCE`.
+- **The standard-error / variance output contract is now uniform and opt-in.** `area()` and `volume()` no longer emit variance columns by default — pass `variance=True`. Variance columns use the standard-error-mirrored name (e.g. `VOLCFNET_TOTAL_SE` → `VOLCFNET_TOTAL_VARIANCE`, `AREA_SE_PERCENT` → `AREA_VARIANCE_PERCENT`); `tpa()`'s previous `*_VAR` columns are renamed to `*_VARIANCE`. `area_change()` now follows the same contract: it always returns `AREA_CHANGE_SE` and adds `AREA_CHANGE_VARIANCE` only with `variance=True` (replacing the previous `se_total`/`variance_total` columns).
 - **GRM estimators no longer silently accept `tree_type="all"`/`"dead"`** (part of #111) — these previously fell through to growing stock; they now raise a clear `ValueError`.
+- **`mortality(tree_type="sawtimber")` now matches `tree_type="sl"` exactly** — a redundant diameter/`VOLCSNET` filter was removed; the GRM `SL` population columns already encode sawtimber, so the two aliases are guaranteed identical.
 
 ## [1.4.1] - 2026-06-30
 

--- a/docs/api/pyfia-estimation-estimators-area.mdx
+++ b/docs/api/pyfia-estimation-estimators-area.mdx
@@ -14,7 +14,7 @@ Simple, straightforward implementation without unnecessary abstractions.
 
 ## Functions
 
-### `area` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L575" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `area` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L581" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 area(db: str | FIA, grp_by: str | list[str] | None = None, land_type: str = 'forest', area_domain: str | None = None, plot_domain: str | None = None, most_recent: bool = False, eval_type: str | None = None, variance: bool = False, totals: bool = True) -> pl.DataFrame
@@ -212,7 +212,7 @@ get_cond_columns(self) -> list[str]
 Get required condition columns based on actual usage.
 
 
-#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L89" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L95" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_values(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -224,7 +224,7 @@ For area estimation, the value is CONDPROP_UNADJ multiplied by
 the domain indicator to properly handle domain estimation.
 
 
-#### `apply_filters` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L108" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `apply_filters` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L114" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 apply_filters(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -239,7 +239,7 @@ This method operates entirely on LazyFrames to enable server-side
 execution on cloud backends like MotherDuck.
 
 
-#### `aggregate_results` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L210" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `aggregate_results` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L216" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 aggregate_results(self, data: pl.LazyFrame | None) -> AggregationResult
@@ -252,7 +252,7 @@ Aggregate area with stratification, preserving data for variance calculation.
 and group_cols for explicit variance calculation.
 
 
-#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L298" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L304" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_variance(self, agg_result: AggregationResult) -> pl.DataFrame
@@ -271,7 +271,7 @@ and group_cols from aggregate_results().
 - Results with variance columns added.
 
 
-#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L543" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area.py#L549" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 format_output(self, results: pl.DataFrame) -> pl.DataFrame

--- a/docs/api/pyfia-estimation-estimators-area_change.mdx
+++ b/docs/api/pyfia-estimation-estimators-area_change.mdx
@@ -47,16 +47,18 @@ points contribute to the estimate.
 If False, return total change over remeasurement period
 - `grp_by`: Column(s) to group results by (e.g., 'OWNGRPCD', 'FORTYPCD')
 - `area_domain`: SQL-like filter expression for conditions
-- `variance`: Whether to calculate sampling variance and standard error
+- `variance`: If True, also return the AREA_CHANGE_VARIANCE column alongside
+AREA_CHANGE_SE (which is always returned). Variance = SE squared.
 - `totals`: Whether to include totals row
 
 **Returns:**
 - Area change estimates with columns:
 - STATECD: State FIPS code
 - AREA_CHANGE_TOTAL: Area change (acres/year if annual=True, else acres)
+- AREA_CHANGE_SE: Standard error of the total
 - N_PLOTS: Number of remeasured plots
-- SE: Standard error (if variance=True)
-- VARIANCE: Sampling variance (if variance=True)
+- AREA_CHANGE_VARIANCE: Variance of the total, = AREA_CHANGE_SE squared
+  (if variance=True)
 - Grouping columns (if grp_by specified)
 
 
@@ -96,7 +98,7 @@ Results are annualized by dividing by the remeasurement period (REMPER).
 
 **Methods:**
 
-#### `get_required_tables` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L76" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `get_required_tables` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L77" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_required_tables(self) -> list[str]
@@ -105,7 +107,7 @@ get_required_tables(self) -> list[str]
 Area change requires SUBP_COND_CHNG_MTRX, COND, PLOT, and stratification.
 
 
-#### `get_cond_columns` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L86" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `get_cond_columns` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L87" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 get_cond_columns(self) -> list[str]
@@ -114,7 +116,7 @@ get_cond_columns(self) -> list[str]
 Get required condition columns.
 
 
-#### `load_data` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L112" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `load_data` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L113" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 load_data(self) -> pl.LazyFrame | None
@@ -130,7 +132,7 @@ Join sequence:
 5. Stratification data - for expansion factors
 
 
-#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L238" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L239" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_values(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -146,7 +148,7 @@ For each subplot-condition, determine if it represents:
 The change value is weighted by SUBPTYP_PROP_CHNG.
 
 
-#### `apply_filters` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L278" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `apply_filters` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L279" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 apply_filters(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -158,7 +160,7 @@ For area change, we keep all remeasured subplot-conditions
 but the change calculation already handles the forest/non-forest logic.
 
 
-#### `aggregate_to_plot` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L299" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `aggregate_to_plot` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L300" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 aggregate_to_plot(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -170,7 +172,7 @@ Sum change values across all subplots within each plot,
 then apply expansion factors.
 
 
-#### `apply_expansion_factors` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L343" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `apply_expansion_factors` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L344" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 apply_expansion_factors(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -182,7 +184,7 @@ For area change, we multiply by EXPNS * ADJ_FACTOR_SUBP.
 If annual=True (default), we also divide by REMPER.
 
 
-#### `calculate_totals` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L377" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_totals` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L378" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_totals(self, data: pl.LazyFrame) -> pl.DataFrame
@@ -193,7 +195,7 @@ Calculate area change totals by grouping.
 Sum expanded area change values, optionally by grouping columns.
 
 
-#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L417" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L418" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_variance(self, result: AggregationResult | pl.DataFrame) -> pl.DataFrame
@@ -204,7 +206,7 @@ Calculate variance for area change estimates.
 Uses stratified variance estimation following Bechtold & Patterson.
 
 
-#### `estimate` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L468" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `estimate` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/area_change.py#L465" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 estimate(self) -> pl.DataFrame
@@ -216,7 +218,9 @@ Run the area change estimation pipeline.
 - Area change estimates with columns:
 - STATECD: State code
 - AREA_CHANGE_TOTAL: Total area change (acres or acres/year)
+- AREA_CHANGE_SE: Standard error of the total
 - N_PLOTS: Number of remeasured plots
-- SE, VARIANCE: (if variance=True) Standard error and variance
+- AREA_CHANGE_VARIANCE: (if variance=True) Variance of the total
+  (= AREA_CHANGE_SE squared)
 - Additional grouping columns if grp_by specified
 

--- a/docs/api/pyfia-estimation-estimators-mortality.mdx
+++ b/docs/api/pyfia-estimation-estimators-mortality.mdx
@@ -15,7 +15,7 @@ annual tree mortality using TREE_GRM_COMPONENT and TREE_GRM_MIDPT tables.
 
 ## Functions
 
-### `mortality` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L262" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+### `mortality` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L255" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 mortality(db: str | FIA, grp_by: str | list[str] | None = None, by_species: bool = False, by_size_class: bool = False, size_class_type: str = 'standard', land_type: str = 'timber', tree_type: str = 'gs', measure: str = 'volume', tree_domain: str | None = None, area_domain: str | None = None, as_rate: bool = False, totals: bool = True, variance: bool = False, most_recent: bool = False) -> pl.DataFrame
@@ -130,7 +130,7 @@ apply_filters(self, data: pl.LazyFrame) -> pl.LazyFrame
 Apply mortality-specific filters.
 
 
-#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L101" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_values` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L94" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_values(self, data: pl.LazyFrame) -> pl.LazyFrame
@@ -141,7 +141,7 @@ Calculate mortality values per acre.
 TPA_UNADJ is already annualized, so no remeasurement period adjustment needed.
 
 
-#### `aggregate_results` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L158" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `aggregate_results` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L151" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 aggregate_results(self, data: pl.LazyFrame | None) -> AggregationResult
@@ -154,7 +154,7 @@ Aggregate mortality with two-stage aggregation.
 explicit variance calculation.
 
 
-#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L202" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `calculate_variance` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L195" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 calculate_variance(self, agg_result: AggregationResult) -> pl.DataFrame
@@ -174,7 +174,7 @@ aggregate_results().
 - Results with variance columns added.
 
 
-#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L253" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
+#### `format_output` <sup><a href="https://github.com/mihiarc/pyfia/blob/main/src/pyfia/estimation/estimators/mortality.py#L246" target="_blank"><Icon icon="github" style="width: 14px; height: 14px;" /></a></sup>
 
 ```python
 format_output(self, results: pl.DataFrame) -> pl.DataFrame

--- a/src/pyfia/estimation/estimators/area.py
+++ b/src/pyfia/estimation/estimators/area.py
@@ -64,14 +64,20 @@ class AreaEstimator(BaseEstimator):
                 if col not in core_cols:
                     filter_cols.add(col)
 
+        # Polygon attributes added by intersect_polygons() live on PLOT (joined
+        # in via the stratification path), not COND. Don't request them from
+        # COND or the COND query raises a BinderException (#116).
+        polygon_attrs: set[str] = set()
+        pa = getattr(self.db, "_polygon_attributes", None)
+        if isinstance(pa, pl.DataFrame):
+            polygon_attrs = {col for col in pa.columns if col != "CN"}
+
         # Add grouping columns if specified
-        grouping_cols = set()
+        grouping_cols: set[str] = set()
         grp_by = self.config.get("grp_by")
         if grp_by:
-            if isinstance(grp_by, str):
-                grouping_cols.add(grp_by)
-            else:
-                grouping_cols.update(grp_by)
+            cols = [grp_by] if isinstance(grp_by, str) else list(grp_by)
+            grouping_cols.update(col for col in cols if col not in polygon_attrs)
 
         # Combine all needed columns
         all_cols = core_cols + list(filter_cols) + list(grouping_cols)

--- a/src/pyfia/estimation/estimators/area_change.py
+++ b/src/pyfia/estimation/estimators/area_change.py
@@ -19,7 +19,7 @@ import polars as pl
 
 from ...core import FIA
 from ..base import AggregationResult, BaseEstimator
-from ..utils import format_output_columns
+from ..utils import apply_variance_columns, format_output_columns
 
 
 class AreaChangeEstimator(BaseEstimator):
@@ -50,7 +50,8 @@ class AreaChangeEstimator(BaseEstimator):
     grp_by : str or list of str, optional
         Column(s) to group results by
     variance : bool, default False
-        Whether to calculate sampling variance
+        If True, also return the AREA_CHANGE_VARIANCE column alongside
+        AREA_CHANGE_SE (which is always returned). Variance = SE squared.
     totals : bool, default False
         Whether to include state totals
 
@@ -450,18 +451,14 @@ class AreaChangeEstimator(BaseEstimator):
             group_cols=group_cols,
         )
 
-        # Join variance to result
-        if group_cols:
-            result = result.join(var_result, on=group_cols, how="left")
-        else:
-            # Single row result
-            if len(var_result) > 0:
-                result = result.with_columns(
-                    [
-                        pl.lit(var_result["VARIANCE"][0]).alias("VARIANCE"),
-                        pl.lit(var_result["SE"][0]).alias("SE"),
-                    ]
-                )
+        # Expose the standard error of the reported total as AREA_CHANGE_SE
+        # (group_cols always includes STATECD, so var_result joins cleanly). The
+        # matching AREA_CHANGE_VARIANCE column (when variance=True) is added
+        # uniformly by apply_variance_columns at the end of estimate().
+        var_result = var_result.select(
+            [*group_cols, pl.col("se_total").alias("AREA_CHANGE_SE")]
+        )
+        result = result.join(var_result, on=group_cols, how="left")
 
         return result
 
@@ -475,8 +472,10 @@ class AreaChangeEstimator(BaseEstimator):
             Area change estimates with columns:
             - STATECD: State code
             - AREA_CHANGE_TOTAL: Total area change (acres or acres/year)
+            - AREA_CHANGE_SE: Standard error of the total
             - N_PLOTS: Number of remeasured plots
-            - SE, VARIANCE: (if variance=True) Standard error and variance
+            - AREA_CHANGE_VARIANCE: (if variance=True) Variance of the total
+              (= AREA_CHANGE_SE squared)
             - Additional grouping columns if grp_by specified
         """
         # Load data
@@ -499,14 +498,15 @@ class AreaChangeEstimator(BaseEstimator):
         # Calculate totals
         result = self.calculate_totals(data)
 
-        # Calculate variance if requested
-        if self.config.get("variance", False):
-            result = self.calculate_variance(result)
+        # Standard errors are always computed (AREA_CHANGE_SE); the matching
+        # AREA_CHANGE_VARIANCE column is added only when variance=True, so the
+        # contract matches every other estimator.
+        result = self.calculate_variance(result)
 
         # Format output columns
         result = format_output_columns(result, "area_change")
 
-        return result
+        return apply_variance_columns(result, self.config.get("variance", False))
 
 
 def area_change(
@@ -547,7 +547,8 @@ def area_change(
     area_domain : str, optional
         SQL-like filter expression for conditions
     variance : bool, default False
-        Whether to calculate sampling variance and standard error
+        If True, also return the AREA_CHANGE_VARIANCE column alongside
+        AREA_CHANGE_SE (which is always returned). Variance = SE squared.
     totals : bool, default False
         Whether to include totals row
 
@@ -557,9 +558,10 @@ def area_change(
         Area change estimates with columns:
         - STATECD: State FIPS code
         - AREA_CHANGE_TOTAL: Area change (acres/year if annual=True, else acres)
+        - AREA_CHANGE_SE: Standard error of the total
         - N_PLOTS: Number of remeasured plots
-        - SE: Standard error (if variance=True)
-        - VARIANCE: Sampling variance (if variance=True)
+        - AREA_CHANGE_VARIANCE: Variance of the total, = AREA_CHANGE_SE squared
+          (if variance=True)
         - Grouping columns (if grp_by specified)
 
     Examples

--- a/src/pyfia/estimation/estimators/mortality.py
+++ b/src/pyfia/estimation/estimators/mortality.py
@@ -78,7 +78,9 @@ class MortalityEstimator(GRMBaseEstimator):
         # Use common GRM filter application
         data = self._apply_grm_filters(data)
 
-        # Additional mortality-specific filters
+        # Additional mortality-specific filters. Sawtimber ('sl'/'sawtimber') is
+        # already encoded by the GRM SL population columns, so it needs no extra
+        # diameter filter here — that kept 'sawtimber' identical to 'sl'.
         tree_type = self.config.get("tree_type", "gs")
 
         if tree_type == "gs":
@@ -86,15 +88,6 @@ class MortalityEstimator(GRMBaseEstimator):
             schema = data.collect_schema().names()
             if "VOLCFNET" in schema:
                 data = data.filter(pl.col("VOLCFNET") > 0)
-        elif tree_type == "sawtimber":
-            # Sawtimber requires larger diameter thresholds
-            data = data.filter(
-                ((pl.col("SPCD") < 300) & (pl.col("DIA_MIDPT") >= 9.0))
-                | ((pl.col("SPCD") >= 300) & (pl.col("DIA_MIDPT") >= 11.0))
-            )
-            schema = data.collect_schema().names()
-            if "VOLCSNET" in schema:
-                data = data.filter(pl.col("VOLCSNET") > 0)
 
         return data
 

--- a/tests/integration/test_estimator_bugs_109_110_111.py
+++ b/tests/integration/test_estimator_bugs_109_110_111.py
@@ -1,4 +1,5 @@
-"""Regression tests for the 1.4.2 estimator bug fixes (#109, #110, #111).
+"""Regression tests for the 1.4.2 estimator bug fixes (#109, #110, #111) and the
+follow-up cleanups (area_change variance contract; #116 spatial grp_by).
 
 These run against the real Georgia FIA database and skip automatically when no
 local database is available (e.g. in CI). The CI-safe guards live in
@@ -7,7 +8,7 @@ tests/unit/test_validation.py and tests/unit/test_variance_columns.py.
 
 import pytest
 
-from pyfia import FIA, biomass, growth, mortality, removals, tpa, volume
+from pyfia import FIA, area_change, biomass, growth, mortality, removals, tpa, volume
 
 pytestmark = [pytest.mark.integration, pytest.mark.db]
 
@@ -116,3 +117,26 @@ class TestGRMTreeType:
         for bad in ("all", "dead"):
             with pytest.raises(ValueError, match="Invalid tree_type"):
                 fn(db, measure="volume", tree_type=bad)
+
+
+class TestAreaChangeVarianceContract:
+    """Follow-up: area_change follows the same SE-always / variance-opt-in contract."""
+
+    def test_area_change_variance_is_additive(self, ga_path):
+        db = FIA(ga_path)
+        db.clip_by_state(GA_FIPS)
+        off = area_change(db, variance=False)
+        on = area_change(db, variance=True)
+
+        # SE is always present; estimate unchanged by the flag.
+        assert "AREA_CHANGE_SE" in off.columns
+        assert "AREA_CHANGE_SE" in on.columns
+        assert off["AREA_CHANGE_TOTAL"][0] == on["AREA_CHANGE_TOTAL"][0]
+
+        # Variance column is opt-in and equals SE squared.
+        assert "AREA_CHANGE_VARIANCE" not in off.columns
+        assert "AREA_CHANGE_VARIANCE" in on.columns
+        if on["AREA_CHANGE_SE"][0] is not None:
+            assert on["AREA_CHANGE_VARIANCE"][0] == pytest.approx(
+                on["AREA_CHANGE_SE"][0] ** 2, rel=1e-9
+            )


### PR DESCRIPTION
## Summary

Folds three follow-up fixes into the **1.4.2** release (version already bumped on `main` by #114; **not yet tagged**) — the #114 review's two nits plus the spatial bug #116. Point estimates and standard errors are unchanged for previously-working queries.

## Fixes

### #116 — `area(grp_by=<intersect_polygons attribute>)` crashed (`BinderException`)
`area.get_cond_columns` added every `grp_by` column to the COND `SELECT` unconditionally, so a spatial attribute like `REGION` (which lives on PLOT, joined via the stratification path) was requested from `COND` → `BinderException`. `area()` now excludes polygon-attribute columns from the COND request. The previously-failing `test_intersect_polygons_with_area_grp_by` now passes. **Closes #116.**

### Nit (a) — `area_change` unified with the variance contract
`area_change` bypassed `apply_variance_columns` and only emitted uncertainty when `variance=True`, as non-standard `se_total`/`variance_total` columns (its ungrouped branch even referenced `SE`/`VARIANCE` columns that never existed). It now always returns **`AREA_CHANGE_SE`** and adds **`AREA_CHANGE_VARIANCE`** (= SE²) only with `variance=True` — matching every other estimator. Estimate unchanged.

### Nit (b) — redundant mortality `sawtimber` filter removed
`mortality.apply_filters` applied an extra DIA/`VOLCSNET` filter for `tree_type="sawtimber"` on top of the GRM `SL` population columns (which already encode sawtimber). Removed, so `"sawtimber"` and `"sl"` are guaranteed identical (behavior-neutral — they were already equal on tested data).

## Verification
- Full suite: **833 passed, 0 failures** (the spatial REGION test now passes). `ruff check`/`format`, `mypy` clean.
- Added an `area_change` variance-contract regression test; verified on the Georgia DB: `area_change` SE always present and `AREA_CHANGE_VARIANCE == SE²`; mortality `sawtimber == sl == 338,792,664` unchanged.
- Regenerated API docs (`area_change` content; `area`/`mortality` source-line-link shifts only).

Closes #116.
