### PR TITLE
docs: final 1.4.2 pass on user-facing guides

### DIFF
--- a/docs/guides/filtering.mdx
+++ b/docs/guides/filtering.mdx
@@ -42,6 +42,10 @@ pyfia.tpa(db, tree_type="live")       # all live trees
   Defaults vary by estimator to match the most common use case — for example,
   `mortality()` defaults to growing stock on timberland. Check each function's
   [API reference](/api/pyfia-estimation-estimators-mortality) for its defaults.
+
+  The growth/removal/mortality estimators (`growth()`, `mortality()`,
+  `removals()`) additionally accept `"al"` (all live) and `"sl"` / `"sawtimber"`
+  (sawtimber-size), which select the matching FIA GRM tree populations.
 </Note>
 
 ## Custom domain filters

--- a/docs/queries/mortality.mdx
+++ b/docs/queries/mortality.mdx
@@ -95,4 +95,4 @@ These EVALIDator translations group growing-stock mortality (trees ≥5" DBH on 
   </Card>
 </CardGroup>
 
-<Tip>The Python equivalent is [`mortality()`](/api/pyfia-estimation-estimators-mortality) — pass `grp_by="AGENTCD"` or `"DSTRBCD1"`, and `variance=True` for standard errors.</Tip>
+<Tip>The Python equivalent is [`mortality()`](/api/pyfia-estimation-estimators-mortality) — pass `grp_by="AGENTCD"` or `"DSTRBCD1"`. Standard errors (`MORT_ACRE_SE`, `MORT_TOTAL_SE`) come back automatically; add `variance=True` for the matching variance columns.</Tip>


### PR DESCRIPTION
Final public-docs pass for the 1.4.2 changes. I audited every human-written `docs/*.mdx` page (guides, concepts, examples, query library) against the shipped 1.4.2 behavior; the auto-generated API reference is already current. Only two stale spots remained — both fixed here and verified against the Georgia DB:

- **`queries/mortality.mdx`** — "pass `variance=True` for standard errors" was wrong under the new contract. Standard errors (`MORT_ACRE_SE`, `MORT_TOTAL_SE`) are now returned automatically; `variance=True` adds the matching `*_VARIANCE` columns. (Verified: default output includes the `_SE` columns; `variance=True` adds `MORT_*_VARIANCE`.)
- **`guides/filtering.mdx`** — the `tree_type` table lists `{live, dead, gs, all}` (correct for area/volume/biomass/tpa) but didn't mention that the GRM estimators also accept `al` and `sl`/`sawtimber` (the #111 capability). Added a note.

Everything else was already consistent: `concepts/variance.mdx` + `getting-started.mdx` describe the new SE/variance contract (updated in #114); `examples.mdx` biomass components and the `vol_type="sawlog"` sawtimber example are correct; `guides/spatial.mdx` uses `tpa` grouping (and `area` grouping now works too, via #116). MDX tags balanced; diff limited to the two prose fixes.

After this merges, 1.4.2 is ready to tag/release.